### PR TITLE
allow ^C to interrupt

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -804,6 +804,9 @@ class Client(object):
             # Can occur if we just reconnected but rlist/wlist contain a -1 for
             # some reason.
             return MQTT_ERR_CONN_LOST
+        except KeyboardInterrupt:
+            # allow ^C to terminate
+            raise
         except:
             return MQTT_ERR_UNKNOWN
 


### PR DESCRIPTION
addresses this issue: https://github.com/eclipse/paho.mqtt.python/issues/8