### PR TITLE
Support to limit the number of pending outgoing messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,6 +200,17 @@ Set the maximum number of messages with QoS>0 that can be part way through their
 
 Defaults to 20. Increasing this value will consume more memory but can increase throughput.
 
+max_queued_messages_set()
+'''''''''''''''''''''''''
+
+::
+
+    max_queued_messages_set(self, queue_size)
+
+Set the maximum number of outgoing messages with QoS>0 that can be pending in the outgoing message queue.
+
+Defaults to 0. 0 means unlimited. When the queue is full, any further outgoing messages would be dropped.
+
 message_retry_set()   
 '''''''''''''''''''
 


### PR DESCRIPTION
When there's no limitation, the library itself would queue all messages
with QoS > 0 if the messages can not be delivered. This can make the
queue grow to an unreasonable size and lead an out-of-memory issue.
For example, if the user keep publishing messages when the messages
cannot be sent successfully.

Signed-off-by: Chang Yu-heng <mr.changyuheng@gmail.com>