### PR TITLE
Fix loop_start() raising exception when no internet

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2280,14 +2280,7 @@ class Client(object):
         self._callback_mutex.release()
 
     def _thread_main(self):
-        self._state_mutex.acquire()
-        if self._state == mqtt_cs_connect_async:
-            self._state_mutex.release()
-            self.reconnect()
-        else:
-            self._state_mutex.release()
-
-        self.loop_forever()
+        self.loop_forever(retry_first_connection=True)
 
     def _host_matches_cert(self, host, cert_host):
         if cert_host[0:2] == "*.":

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1244,6 +1244,9 @@ class Client(object):
         run = True
 
         while run:
+            if self._thread_terminate is True:
+                break
+
             if self._state == mqtt_cs_connect_async:
                 try:
                     self.reconnect()


### PR DESCRIPTION
The user should be able to use the library as the following steps without worry about the socket.error.

```py
import paho.mqtt.client as mqttc

client = mqttc.Client()
client.connect_async('mqtt.example.com')
client.loop_start()
```