### PR TITLE
use a topic matcher for better performance

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -199,6 +199,23 @@ def connack_string(connack_code):
         return "Connection Refused: unknown reason."
 
 
+def topic_matches_sub(sub, topic):
+    """Check whether a topic matches a subscription.
+
+    For example:
+
+    foo/bar would match the subscription foo/# or +/bar
+    non/matching would not match the subscription non/+/+
+    """
+    matcher = MQTTMatcher()
+    matcher[sub] = True
+    try:
+        next(matcher.iter_match(topic))
+        return True
+    except StopIteration:
+        return False
+
+
 def _socketpair_compat():
     """TCP/IP socketpair including Windows support"""
     listensock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_IP)

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -50,6 +50,8 @@ try:
 except ImportError:
     HAVE_DNS = False
 
+from .matcher import MQTTMatcher
+
 if platform.system() == 'Windows':
     EAGAIN = errno.WSAEWOULDBLOCK
 else:
@@ -195,71 +197,6 @@ def connack_string(connack_code):
         return "Connection Refused: not authorised."
     else:
         return "Connection Refused: unknown reason."
-
-
-def topic_matches_sub(sub, topic):
-    """Check whether a topic matches a subscription.
-
-    For example:
-
-    foo/bar would match the subscription foo/# or +/bar
-    non/matching would not match the subscription non/+/+
-    """
-    result = True
-    multilevel_wildcard = False
-
-    slen = len(sub)
-    tlen = len(topic)
-
-    if slen > 0 and tlen > 0:
-        if (sub[0] == '$' and topic[0] != '$') or (topic[0] == '$' and sub[0] != '$'):
-            return False
-
-    spos = 0
-    tpos = 0
-
-    while spos < slen and tpos < tlen:
-        if sub[spos] == topic[tpos]:
-            if tpos == tlen-1:
-                # Check for e.g. foo matching foo/#
-                if spos == slen-3 and sub[spos+1] == '/' and sub[spos+2] == '#':
-                    result = True
-                    multilevel_wildcard = True
-                    break
-
-            spos += 1
-            tpos += 1
-
-            if tpos == tlen and spos == slen-1 and sub[spos] == '+':
-                spos += 1
-                result = True
-                break
-        else:
-            if sub[spos] == '+':
-                spos += 1
-                while tpos < tlen and topic[tpos] != '/':
-                    tpos += 1
-                if tpos == tlen and spos == slen:
-                    result = True
-                    break
-
-            elif sub[spos] == '#':
-                multilevel_wildcard = True
-                if spos+1 != slen:
-                    result = False
-                    break
-                else:
-                    result = True
-                    break
-
-            else:
-                result = False
-                break
-
-    if not multilevel_wildcard and (tpos < tlen or spos < slen):
-        result = False
-
-    return result
 
 
 def _socketpair_compat():
@@ -535,7 +472,7 @@ class Client(object):
         self._will_payload = None
         self._will_qos = 0
         self._will_retain = False
-        self.on_message_filtered = []
+        self._on_message_filtered = MQTTMatcher()
         self._host = ""
         self._port = 1883
         self._bind_address = ""
@@ -1632,14 +1569,7 @@ class Client(object):
             raise ValueError("sub and callback must both be defined.")
 
         self._callback_mutex.acquire()
-
-        for i in range(0, len(self.on_message_filtered)):
-            if self.on_message_filtered[i][0] == sub:
-                self.on_message_filtered[i] = (sub, callback)
-                self._callback_mutex.release()
-                return
-
-        self.on_message_filtered.append((sub, callback))
+        self._on_message_filtered[sub] = callback
         self._callback_mutex.release()
 
     def message_callback_remove(self, sub):
@@ -1649,11 +1579,10 @@ class Client(object):
             raise ValueError("sub must defined.")
 
         self._callback_mutex.acquire()
-        for i in range(0, len(self.on_message_filtered)):
-            if self.on_message_filtered[i][0] == sub:
-                self.on_message_filtered.pop(i)
-                self._callback_mutex.release()
-                return
+        try:
+            del self._on_message_filtered[sub]
+        except KeyError:  # no such subscription
+            pass
         self._callback_mutex.release()
 
     # ============================================================
@@ -2568,12 +2497,11 @@ class Client(object):
     def _handle_on_message(self, message):
         self._callback_mutex.acquire()
         matched = False
-        for t in self.on_message_filtered:
-            if topic_matches_sub(t[0], message.topic):
-                self._in_callback = True
-                t[1](self, self._userdata, message)
-                self._in_callback = False
-                matched = True
+        for callback in self._on_message_filtered.iter_match(message.topic):
+            self._in_callback = True
+            callback(self, self._userdata, message)
+            self._in_callback = False
+            matched = True
 
         if matched == False and self.on_message:
             self._in_callback = True

--- a/src/paho/mqtt/matcher.py
+++ b/src/paho/mqtt/matcher.py
@@ -1,0 +1,78 @@
+class MQTTMatcher(object):
+    """Intended to manage topic filters including wildcards.
+
+    Internally, MQTTMatcher use a prefix tree (trie) to store 
+    values associated with filters, and has an iter_match() 
+    method to iterate efficiently over all filters that match 
+    some topic name."""
+
+    class Node(object):
+        __slots__ = '_children', '_content'
+
+        def __init__(self):
+            self._children = {}
+            self._content = None
+
+    def __init__(self):
+        self._root = self.Node()
+
+    def __setitem__(self, key, value):
+        """Add a topic filter :key to the prefix tree 
+        and associate it to :value"""
+        node = self._root
+        for sym in key.split('/'):
+            node = node._children.setdefault(sym, self.Node())
+        node._content = value
+
+    def __getitem__(self, key):
+        """Retrieve the value associated with some topic filter :key"""
+        try:
+            node = self._root
+            for sym in key.split('/'):
+                node = node._children[sym]
+            if node._content is None:
+                raise KeyError(key)
+            return node._content
+        except KeyError:
+            raise KeyError(key)
+
+    def __delitem__(self, key):
+        """Delete the value associated with some topic filter :key"""
+        lst = []
+        try:
+            parent, node = None, self._root
+            for k in key.split('/'):
+                 parent, node = node, node._children[k]
+                 lst.append((parent, k, node))
+            # TODO
+            node._content = None
+        except KeyError:
+            raise KeyError(key)
+        else:  # cleanup
+            for parent, k, node in reversed(lst):
+                if node._children or node._content is not None:
+                     break
+                del parent._children[k]
+
+    def iter_match(self, topic):
+        """Return an iterator on all values associated with filters 
+        that match the :topic"""
+        lst = topic.split('/')
+        normal = not topic.startswith('$')
+        def rec(node, i=0):
+            if i == len(lst):
+                if node._content is not None:
+                    yield node._content
+            else:
+                part = lst[i]
+                if part in node._children:
+                    for content in rec(node._children[part], i + 1):
+                        yield content
+                if '+' in node._children and (normal or i > 0):
+                    for content in rec(node._children['+'], i + 1):
+                        yield content
+            if '#' in node._children and (normal or i > 0):
+                content = node._children['#']._content
+                if content is not None:
+                    yield content
+        return rec(self._root)


### PR DESCRIPTION
I wrote a new class called `MQTTMatcher`for managing callbacks. Also fix https://github.com/eclipse/paho.mqtt.python/issues/67

Here a simple benchmark (1000 topics and 1000 corresponding subscriptions) : 

```python
from random import *
from string import ascii_lowercase as charset
from time import time

N = 1000

def gen(sz):
    return '/'.join(choice(charset) for _ in range(sz))

def to_filter(topic):
    lst = topic.split('/')
    i = randrange(0, len(lst))
    if random() < 0.5:
        lst[i] = '+'
    else:
        lst[i:] = ['#']
    return '/'.join(lst)


topics = [gen(randint(2,7)) for _ in range(N)]
filters = [to_filter(topic) for topic in topics]

matcher = MQTTMatcher()
for f in filters:
    matcher[f] = f

t1 = time()
dct1 = {t: set(matcher.subscribers(t)) for t in topics}
t2 = time()
print('MQTTMatcher: matching %d topics in %gs' % (N, t2 - t1))

t1 = time()
dct2 = {}
for t in topics:
    dct2[t] = set()
    for f in filters:
        if topic_matches_sub(f, t):
            dct2[t].add(f)

t2 = time()
print('topic_matches_sub: matching %d topics in %gs' % (N, t2 - t1))

assert dct1 == dct2
```

The result is very eloquent : 

```
MQTTMatcher: matching 1000 topics in 0s
topic_matches_sub: matching 1000 topics in 1.48453s
```

This is because current implementation is in O(N) for each topic, which are tested against all subscriptions.