### PR TITLE
simplifying ssl

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -504,7 +504,7 @@ class Client(object):
         self._in_message_mutex = threading.Lock()
         self._thread = None
         self._thread_terminate = False
-        self._ssl = None
+        self._ssl = False
         self._tls_certfile = None
         self._tls_keyfile = None
         self._tls_ca_certs = None
@@ -525,11 +525,7 @@ class Client(object):
         pass
 
     def reinitialise(self, client_id="", clean_session=True, userdata=None):
-        if self._ssl:
-            self._ssl.close()
-            self._ssl = None
-            self._sock = None
-        elif self._sock:
+        if self._sock:
             self._sock.close()
             self._sock = None
         if self._sockpairR:
@@ -606,6 +602,7 @@ class Client(object):
             else:
                 f.close()
 
+        self._ssl = True
         self._tls_ca_certs = ca_certs
         self._tls_certfile = certfile
         self._tls_keyfile = keyfile
@@ -662,7 +659,7 @@ class Client(object):
 
         try:
             rr = '_mqtt._tcp.%s' % domain
-            if self._ssl is not None:
+            if self._ssl:
                 # IANA specifies secure-mqtt (not mqtts) for port 8883
                 rr = '_secure-mqtt._tcp.%s' % domain
             answers = []
@@ -750,11 +747,7 @@ class Client(object):
         self._state_mutex.acquire()
         self._state = mqtt_cs_new
         self._state_mutex.release()
-        if self._ssl:
-            self._ssl.close()
-            self._ssl = None
-            self._sock = None
-        elif self._sock:
+        if self._sock:
             self._sock.close()
             self._sock = None
 
@@ -771,7 +764,7 @@ class Client(object):
                 raise
 
         if self._tls_ca_certs is not None:
-            self._ssl = ssl.wrap_socket(
+            sock = ssl.wrap_socket(
                 sock,
                 certfile=self._tls_certfile,
                 keyfile=self._tls_keyfile,
@@ -781,22 +774,19 @@ class Client(object):
                 ciphers=self._tls_ciphers)
 
             if self._tls_insecure is False:
-                if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 2):
-                    self._tls_match_hostname()
+                if sys.version_info < (2,7,9) or (sys.version_info[0] == 3 and sys.version_info[1] < 2):
+                    self._tls_match_hostname(sock)
                 else:
-                    ssl.match_hostname(self._ssl.getpeercert(), self._host)
+                    ssl.match_hostname(sock.getpeercert(), self._host)
 
         if self._transport == "websockets":
             if self._tls_ca_certs is not None:
-                self._ssl = WebsocketWrapper(self._ssl, self._host, self._port, True)
+                sock = WebsocketWrapper(sock, self._host, self._port, True)
             else:
                 sock = WebsocketWrapper(sock, self._host, self._port, False)
 
         self._sock = sock
-        if self._ssl:
-            self._ssl.setblocking(0)
-        else:
-            self._sock.setblocking(0)
+        self._sock.setblocking(0)
 
         return self._send_connect(self._keepalive, self._clean_session)
 
@@ -829,7 +819,7 @@ class Client(object):
             self._current_out_packet = self._out_packet.pop(0)
 
         if self._current_out_packet:
-            wlist = [self.socket()]
+            wlist = [self._sock]
         else:
             wlist = []
         self._out_packet_mutex.release()
@@ -837,7 +827,7 @@ class Client(object):
 
         # sockpairR is used to break out of select() before the timeout, on a
         # call to publish() etc.
-        rlist = [self.socket(), self._sockpairR]
+        rlist = [self._sock, self._sockpairR]
         try:
             socklist = select.select(rlist, wlist, [], timeout)
         except TypeError:
@@ -853,15 +843,15 @@ class Client(object):
         except:
             return MQTT_ERR_UNKNOWN
 
-        if self.socket() in socklist[0]:
+        if self._sock in socklist[0]:
             rc = self.loop_read(max_packets)
-            if rc or (self._ssl is None and self._sock is None):
+            if rc or self._sock is None:
                 return rc
 
         if self._sockpairR in socklist[0]:
             # Stimulate output write even though we didn't ask for it, because
             # at that point the publish or other command wasn't present.
-            socklist[1].insert(0, self.socket())
+            socklist[1].insert(0, self._sock)
             # Clear sockpairR - only ever a single byte written.
             try:
                 self._sockpairR.recv(1)
@@ -869,9 +859,9 @@ class Client(object):
                 if err.errno != EAGAIN:
                     raise
 
-        if self.socket() in socklist[1]:
+        if self._sock in socklist[1]:
             rc = self.loop_write(max_packets)
-            if rc or (self._ssl is None and self._sock is None):
+            if rc or self._sock is None:
                 return rc
 
         return self.loop_misc()
@@ -1002,7 +992,7 @@ class Client(object):
         self._state = mqtt_cs_disconnecting
         self._state_mutex.release()
 
-        if self._sock is None and self._ssl is None:
+        if self._sock is None:
             return MQTT_ERR_NO_CONN
 
         return self._send_disconnect()
@@ -1075,7 +1065,7 @@ class Client(object):
         if topic_qos_list is None:
             raise ValueError("No topic specified, or incorrect topic type.")
 
-        if self._sock is None and self._ssl is None:
+        if self._sock is None:
             return (MQTT_ERR_NO_CONN, None)
 
         return self._send_subscribe(False, topic_qos_list)
@@ -1113,7 +1103,7 @@ class Client(object):
         if topic_list is None:
             raise ValueError("No topic specified, or incorrect topic type.")
 
-        if self._sock is None and self._ssl is None:
+        if self._sock is None:
             return (MQTT_ERR_NO_CONN, None)
 
         return self._send_unsubscribe(False, topic_list)
@@ -1126,7 +1116,7 @@ class Client(object):
         on.
 
         Do not use if you are using the threaded interface loop_start()."""
-        if self._sock is None and self._ssl is None:
+        if self._sock is None:
             return MQTT_ERR_NO_CONN
 
         max_packets = len(self._out_messages) + len(self._in_messages)
@@ -1151,7 +1141,7 @@ class Client(object):
         Use want_write() to determine if there is data waiting to be written.
 
         Do not use if you are using the threaded interface loop_start()."""
-        if self._sock is None and self._ssl is None:
+        if self._sock is None:
             return MQTT_ERR_NO_CONN
 
         max_packets = len(self._out_packet) + 1
@@ -1180,7 +1170,7 @@ class Client(object):
         wish to call select() or equivalent on.
 
         Do not use if you are using the threaded interface loop_start()."""
-        if self._sock is None and self._ssl is None:
+        if self._sock is None:
             return MQTT_ERR_NO_CONN
 
         now = time_func()
@@ -1193,10 +1183,7 @@ class Client(object):
         if self._ping_t > 0 and now - self._ping_t >= self._keepalive:
             # client->ping_t != 0 means we are waiting for a pingresp.
             # This hasn't happened in the keepalive time so we should disconnect.
-            if self._ssl:
-                self._ssl.close()
-                self._ssl = None
-            elif self._sock:
+            if self._sock:
                 self._sock.close()
                 self._sock = None
 
@@ -1293,10 +1280,7 @@ class Client(object):
 
     def socket(self):
         """Return the socket or ssl object for this client."""
-        if self._ssl:
-            return self._ssl
-        else:
-            return self._sock
+        return self._sock
 
     def loop_forever(self, timeout=1.0, max_packets=1, retry_first_connection=False):
         """This function call loop() for you in an infinite blocking loop. It
@@ -1608,10 +1592,7 @@ class Client(object):
 
     def _loop_rc_handle(self, rc):
         if rc:
-            if self._ssl:
-                self._ssl.close()
-                self._ssl = None
-            elif self._sock:
+            if self._sock:
                 self._sock.close()
                 self._sock = None
 
@@ -1644,10 +1625,7 @@ class Client(object):
         # Finally, free the memory and reset everything to starting conditions.
         if self._in_packet['command'] == 0:
             try:
-                if self._ssl:
-                    command = self._ssl.read(1)
-                else:
-                    command = self._sock.recv(1)
+                command = self._sock.recv(1)
             except socket.error as err:
                 if self._ssl and (err.errno == ssl.SSL_ERROR_WANT_READ or err.errno == ssl.SSL_ERROR_WANT_WRITE):
                     return MQTT_ERR_AGAIN
@@ -1667,10 +1645,7 @@ class Client(object):
             # http://publib.boulder.ibm.com/infocenter/wmbhelp/v6r0m0/topic/com.ibm.etools.mft.doc/ac10870_.htm
             while True:
                 try:
-                    if self._ssl:
-                        byte = self._ssl.read(1)
-                    else:
-                        byte = self._sock.recv(1)
+                    byte = self._sock.recv(1)
                 except socket.error as err:
                     if self._ssl and (err.errno == ssl.SSL_ERROR_WANT_READ or err.errno == ssl.SSL_ERROR_WANT_WRITE):
                         return MQTT_ERR_AGAIN
@@ -1698,10 +1673,7 @@ class Client(object):
 
         while self._in_packet['to_process'] > 0:
             try:
-                if self._ssl:
-                    data = self._ssl.read(self._in_packet['to_process'])
-                else:
-                    data = self._sock.recv(self._in_packet['to_process'])
+                data = self._sock.recv(self._in_packet['to_process'])
             except socket.error as err:
                 if self._ssl and (err.errno == ssl.SSL_ERROR_WANT_READ or err.errno == ssl.SSL_ERROR_WANT_WRITE):
                     return MQTT_ERR_AGAIN
@@ -1740,10 +1712,7 @@ class Client(object):
             packet = self._current_out_packet
 
             try:
-                if self._ssl:
-                    write_length = self._ssl.write(packet['packet'][packet['pos']:])
-                else:
-                    write_length = self._sock.send(packet['packet'][packet['pos']:])
+                write_length = self._sock.send(packet['packet'][packet['pos']:])
             except (AttributeError, ValueError):
                 self._current_out_packet_mutex.release()
                 return MQTT_ERR_SUCCESS
@@ -1785,9 +1754,6 @@ class Client(object):
                             self._in_callback = False
                         self._callback_mutex.release()
 
-                        if self._ssl:
-                            self._ssl.close()
-                            self._ssl = None
                         if self._sock:
                             self._sock.close()
                             self._sock = None
@@ -1823,7 +1789,7 @@ class Client(object):
         last_msg_out = self._last_msg_out
         last_msg_in = self._last_msg_in
         self._msgtime_mutex.release()
-        if (self._sock is not None or self._ssl is not None) and (now - last_msg_out >= self._keepalive or now - last_msg_in >= self._keepalive):
+        if self._sock is not None and (now - last_msg_out >= self._keepalive or now - last_msg_in >= self._keepalive):
             if self._state == mqtt_cs_connected and self._ping_t == 0:
                 self._send_pingreq()
                 self._msgtime_mutex.acquire()
@@ -1831,10 +1797,7 @@ class Client(object):
                 self._last_msg_in = now
                 self._msgtime_mutex.release()
             else:
-                if self._ssl:
-                    self._ssl.close()
-                    self._ssl = None
-                elif self._sock:
+                if self._sock:
                     self._sock.close()
                     self._sock = None
 
@@ -1925,7 +1888,7 @@ class Client(object):
                 raise TypeError
 
     def _send_publish(self, mid, topic, payload=None, qos=0, retain=False, dup=False, info=None):
-        if self._sock is None and self._ssl is None:
+        if self._sock is None:
             return MQTT_ERR_NO_CONN
 
         utopic = topic.encode('utf-8')
@@ -2547,9 +2510,9 @@ class Client(object):
             else:
                 return False
 
-    def _tls_match_hostname(self):
+    def _tls_match_hostname(self, sock):
         try:
-            cert = self._ssl.getpeercert()
+            cert = sock.getpeercert()
         except AttributeError:
             # the getpeercert can throw Attribute error: object has no attribute 'peer_certificate'
             # Don't let that crash the whole client. See also: http://bugs.python.org/issue13721
@@ -2632,20 +2595,14 @@ class WebsocketWrapper:
                  b"Sec-WebSocket-Version: 13\r\n" +\
                  b"Sec-WebSocket-Protocol: mqtt\r\n\r\n"
 
-        if self._ssl:
-            self._socket.write(header)
-        else:
-            self._socket.send(header)
+        self._socket.send(header)
 
         has_secret = False
         has_upgrade = False
 
         while True:
             # read HTTP response header as lines
-            if self._ssl:
-                byte = self._socket.read(1)
-            else:
-                byte = self._socket.recv(1)
+            byte = self._socket.recv(1)
 
             self._readbuffer.extend(byte)
             # line end
@@ -2726,10 +2683,7 @@ class WebsocketWrapper:
         # try to recv and strore needed bytes
         if self._readbuffer_head + length > len(self._readbuffer):
 
-            if self._ssl:
-                data = self._socket.read(self._readbuffer_head + length - len(self._readbuffer))
-            else:
-                data = self._socket.recv(self._readbuffer_head + length - len(self._readbuffer))
+            data = self._socket.recv(self._readbuffer_head + length - len(self._readbuffer))
 
             if not data:
                 raise socket.error(errno.ECONNABORTED, 0)
@@ -2802,17 +2756,11 @@ class WebsocketWrapper:
                 # respond to non-binary opcodes, their arrival is not guaranteed beacause of non-blocking sockets
                 if opcode == WebsocketWrapper.OPCODE_CONNCLOSE:
                     frame = self._create_frame(WebsocketWrapper.OPCODE_CONNCLOSE, payload, 0)
-                    if self._ssl:
-                        self._socket.write(frame)
-                    else:
-                        self._socket.send(frame)
+                    self._socket.send(frame)
 
                 if opcode == WebsocketWrapper.OPCODE_PING:
                     frame = self._create_frame(WebsocketWrapper.OPCODE_PONG, payload, 0)
-                    if self._ssl:
-                        self._socket.write(frame)
-                    else:
-                        self._socket.send(frame)
+                    self._socket.send(frame)
 
             if opcode == WebsocketWrapper.OPCODE_BINARY:
                 return result
@@ -2839,10 +2787,7 @@ class WebsocketWrapper:
             self._requested_size = len(data)
 
         # try to write out as much as possible
-        if self._ssl:
-            length = self._socket.write(self._sendbuffer)
-        else:
-            length = self._socket.send(self._sendbuffer)
+        length = self._socket.send(self._sendbuffer)
 
         self._sendbuffer = self._sendbuffer[length:]
 


### PR DESCRIPTION
I don't understand the need to manage two sockets for the ssl support (this makes the code more complicated).

Here an attempt to make it simpler with assigning `self._sock` to the ssl wrapper directly. Tested and apparently works well.

If there is a mistake with this approach, please can you explain the reason to manage two separate sockets ?