### PR TITLE
helpers: publish messages in order

### DIFF
--- a/src/paho/mqtt/publish.py
+++ b/src/paho/mqtt/publish.py
@@ -25,7 +25,7 @@ import paho.mqtt as mqtt
 
 def _do_publish(c):
     """Internal function"""
-    m = c._userdata.pop()
+    m = c._userdata.pop(0)
     if type(m) is dict:
         topic = m['topic']
         try:


### PR DESCRIPTION
This has "less" performance, but is likely to be a lot closer to what
people actually expect to happen, rather than the current behaviour of
publishing in reverse order.

Signed-off-by: Karl Palsson karlp@tweak.net.au

See also: https://github.com/eclipse/paho.mqtt.python/pull/64 which deal with the performance implications of lists vs deques for ordered popping.
