### PR TITLE
allow to set custom URL path for MQTT over WS usage

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -531,6 +531,7 @@ class Client(object):
         self._will_retain = False
         self.on_message_filtered = []
         self._host = ""
+        self._path= "/mqtt"
         self._port = 1883
         self._bind_address = ""
         self._in_callback = False
@@ -828,9 +829,9 @@ class Client(object):
 
         if self._transport == "websockets":
             if self._tls_ca_certs is not None:
-                self._ssl = WebsocketWrapper(self._ssl, self._host, self._port, True)
+                self._ssl = WebsocketWrapper(self._ssl, self._host, self._path, self._port, True)
             else:
-                sock = WebsocketWrapper(sock, self._host, self._port, False)
+                sock = WebsocketWrapper(sock, self._host, self._path, self._port, False)
 
         self._sock = sock
         if self._ssl:
@@ -1023,6 +1024,9 @@ class Client(object):
                 self._out_message_mutex.release()
                 message.info.rc = MQTT_ERR_SUCCESS
                 return message.info
+
+    def endpoint_url_path_set(self, path):
+        self._path=path
 
     def username_pw_set(self, username, password=None):
         """Set a username and optionally a password for broker authentication.
@@ -2644,12 +2648,13 @@ class WebsocketWrapper:
     OPCODE_PING = 0x9
     OPCODE_PONG = 0xa
 
-    def __init__(self, socket, host, port, is_ssl):
+    def __init__(self, socket, host, path, port, is_ssl):
 
         self.connected = False
 
         self._ssl = is_ssl
         self._host = host
+        self._path = path
         self._port = port
         self._socket = socket
 
@@ -2672,7 +2677,7 @@ class WebsocketWrapper:
         sec_websocket_key = uuid.uuid4().bytes
         sec_websocket_key = base64.b64encode(sec_websocket_key)
 
-        header = b"GET /mqtt HTTP/1.1\r\n" +\
+        header = b"GET " + str(self._path).encode('utf-8') + b" HTTP/1.1\r\n" +\
                  b"Upgrade: websocket\r\n" +\
                  b"Connection: Upgrade\r\n" +\
                  b"Host: " + str(self._host).encode('utf-8') + b":" + str(self._port).encode('utf-8') + b"\r\n" +\


### PR DESCRIPTION
The recent MQTT spec allows URL paths other than /mqtt when using a WebSocket transport. The suggested modification keeps the current behavior but allows
to set a custom URL path using
    endpoint_url_path_set(self, path):
