### PR TITLE
Fix publish on  Python3 with QoS > 0

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -347,11 +347,13 @@ class MQTTMessage:
 
     Members:
 
-    topic : String. topic that the message was published on.
+    topic : String/bytes. topic that the message was published on.
     payload : String/bytes the message payload.
     qos : Integer. The message Quality of Service 0, 1 or 2.
     retain : Boolean. If true, the message is a retained message and not fresh.
     mid : Integer. The message id.
+
+    On Python 3, topic must be bytes.
     """
     def __init__(self, mid=0, topic=""):
         self.timestamp = 0
@@ -992,7 +994,10 @@ class Client(object):
             info.rc = rc
             return info
         else:
-            message = MQTTMessage(local_mid, topic)
+            if sys.version_info[0] >= 3:
+                message = MQTTMessage(local_mid, topic.encode('utf-8'))
+            else:
+                message = MQTTMessage(local_mid, topic)
             message.timestamp = time_func()
 
             if local_payload is None or len(local_payload) == 0:


### PR DESCRIPTION
#75 introduced a regression with Python 3 clients. When trying to publish a message with QoS > 0, the following error occurred:

```
Traceback (most recent call last):
  File "simple.py", line 4, in <module>
    client.publish('mytopic', 'mymessage', 1)
  File "/home/pierref/dev/ext/paho.mqtt.python/src/paho/mqtt/client.py", line 1022, in publish
    rc = self._send_publish(message.mid, message.topic, message.payload, message.qos, message.retain, message.dup)
  File "/home/pierref/dev/ext/paho.mqtt.python/src/paho/mqtt/client.py", line 370, in topic
    return self._topic.decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
```

This PR fix the issue by encoding topic to UTF-8 before creating the MQTTMessage object.

To reproduce the issue, i used this script (simple.py):

```
import paho.mqtt.client as mqtt

client = mqtt.Client()
client.publish('mytopic', 'mymessage', 1)
```