### PR TITLE
Add support for SSL context and SNI

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,7 @@ v1.x - 2016-xx-xx
 - Allow username and password to be zero length (as opposed to not being
   present). Closes #80.
 - Allow zero length client ids when using MQTT v3.1.1.
+- Add SSLContext support, including SNI. Closes #11.
 
 
 v1.2 - 2016-06-03

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -5,6 +5,8 @@ v1.x - 2016-xx-xx
   present). Closes #80.
 - Allow zero length client ids when using MQTT v3.1.1.
 - Add SSLContext support, including SNI. Closes #11.
+- Remove support for SSL without SSLContext (Requires Python 2.7.9+ or 3.2+).
+  Closes #115.
 
 
 v1.2 - 2016-06-03

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ This document describes the source code for the `Eclipse Paho <http://eclipse.or
 
 This code provides a client class which enable applications to connect to an `MQTT <http://mqtt.org/>`_ broker to publish messages, and to subscribe to topics and receive published messages. It also provides some helper functions to make publishing one off messages to an MQTT server very straightforward.
 
-It supports Python 2.7 or 3.x, with limited support for Python 2.6.
+It supports Python 2.7 or 3.2+, with limited support for Python 2.6.
 
 The MQTT protocol is a machine-to-machine (M2M)/"Internet of Things" connectivity protocol. Designed as an extremely lightweight publish/subscribe messaging transport, it is useful for connections with remote locations where a small code footprint is required and/or network bandwidth is at a premium.
 
@@ -263,12 +263,11 @@ tls_set_context()
 Configure network encryption and authentication context. Enables SSL/TLS support.
 
 context
-    an ssl.SSLContext object, or a dictionary containing arguments for ``ssl.wrap_socket``. By default this is given by ``ssl.create_default_context()``, if available (added in Python 3.4).
+    an ssl.SSLContext object. By default, this is given by ``ssl.create_default_context()``, if available (added in Python 3.4).
 
 If you're unsure about using this method, then either use the default context, or use the ``tls_set`` method. See the ssl module documentation section about `security considerations <https://docs.python.org/3/library/ssl.html#ssl-security>`_ for more information.
 
 Must be called before ``connect*()``.
-
 
 tls_insecure_set()
 ''''''''''''''''''
@@ -276,14 +275,14 @@ tls_insecure_set()
 ::
 
     tls_insecure_set(value)
-    
+
 Configure verification of the server hostname in the server certificate.
 
 If ``value`` is set to ``True``, it is impossible to guarantee that the host you are connecting to is not impersonating your server. This can be useful in initial server testing, but makes it possible for a malicious third party to impersonate your server through DNS spoofing, for example.
 
 Do not use this function in a real system. Setting value to True means there is no point using encryption.
 
-Must be called before ``connect*)``.
+Must be called before ``connect*()`` and after ``tls_set()`` or ``tls_set_context()``.
 
 enable_logger()
 '''''''''''''''
@@ -382,7 +381,7 @@ host
 port
     the network port of the server host to connect to. Defaults to 1883. Note
     that the default port for MQTT over SSL/TLS is 8883 so if you are using
-    ``tls_set()`` the port may need providing manually
+    ``tls_set()`` or ``tls_set_context()``, the port may need providing manually
 
 keepalive
     maximum period in seconds allowed between communications with the broker.

--- a/README.rst
+++ b/README.rst
@@ -253,6 +253,23 @@ ciphers
 
 Must be called before ``connect*()``.
 
+tls_set_context()
+'''''''''''''''''
+
+::
+
+    tls_set_context(context)
+
+Configure network encryption and authentication context. Enables SSL/TLS support.
+
+context
+    an ssl.SSLContext object, or a dictionary containing arguments for ``ssl.wrap_socket``. By default this is given by ``ssl.create_default_context()``, if available (added in Python 3.4).
+
+If you're unsure about using this method, then either use the default context, or use the ``tls_set`` method. See the ssl module documentation section about `security considerations <https://docs.python.org/3/library/ssl.html#ssl-security>`_ for more information.
+
+Must be called before ``connect*()``.
+
+
 tls_insecure_set()
 ''''''''''''''''''
 

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -833,6 +833,9 @@ class Client(object):
             try:
                 # Try with server_hostname, even it's not supported in certain scenarios
                 sock = self._ssl_context.wrap_socket(sock, server_hostname=self._host)
+            except ssl.CertificateError:
+                # CertificateError is derived from ValueError
+                raise
             except ValueError:
                 # Python version requires SNI in order to handle server_hostname, but SNI is not available
                 sock = self._ssl_context.wrap_socket(sock)

--- a/src/paho/mqtt/publish.py
+++ b/src/paho/mqtt/publish.py
@@ -88,23 +88,30 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
 
            If a tuple, then it must be of the form:
            ("<topic>", "<payload>", qos, retain)
+
     hostname : a string containing the address of the broker to connect to.
                Defaults to localhost.
+
     port : the port to connect to the broker on. Defaults to 1883.
+
     client_id : the MQTT client id to use. If "" or None, the Paho library will
                 generate a client id automatically.
+
     keepalive : the keepalive timeout value for the client. Defaults to 60
                 seconds.
+
     will : a dict containing will parameters for the client: will = {'topic':
            "<topic>", 'payload':"<payload">, 'qos':<qos>, 'retain':<retain>}.
            Topic is required, all other parameters are optional and will
            default to None, 0 and False respectively.
            Defaults to None, which indicates no will should be used.
+
     auth : a dict containing authentication parameters for the client:
            auth = {'username':"<username>", 'password':"<password>"}
            Username is required, password is optional and will default to None
            if not provided.
            Defaults to None, which indicates no authentication is to be used.
+
     tls : a dict containing TLS configuration parameters for the client:
           dict = {'ca_certs':"<ca_certs>", 'certfile':"<certfile>",
           'keyfile':"<keyfile>", 'tls_version':"<tls_version>",
@@ -112,7 +119,10 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
           ca_certs is required, all other parameters are optional and will
           default to None if not provided, which results in the client using
           the default behaviour - see the paho.mqtt.client documentation.
+          Alternatively, tls input can be an SSLContext object, which will be
+          processed using the tls_set_context method.
           Defaults to None, which indicates that TLS should not be used.
+
     transport : set to "tcp" to use the default setting of transport which is
           raw TCP. Set to "websockets" to use WebSockets as the transport.
     """
@@ -151,25 +161,11 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
         client.will_set(will_topic, will_payload, will_qos, will_retain)
 
     if tls is not None:
-        ca_certs = tls['ca_certs']
-        try:
-            certfile = tls['certfile']
-        except KeyError:
-            certfile = None
-        try:
-            keyfile = tls['keyfile']
-        except KeyError:
-            keyfile = None
-        try:
-            tls_version = tls['tls_version']
-        except KeyError:
-            tls_version = None
-        try:
-            ciphers = tls['ciphers']
-        except KeyError:
-            ciphers = None
-        client.tls_set(ca_certs, certfile, keyfile, tls_version=tls_version,
-                       ciphers=ciphers)
+        if isinstance(tls, dict):
+            client.tls_set(**tls)
+        else:
+            # Assume input is SSLContext object
+            client.tls_set_context(tls)
 
     client.connect(hostname, port, keepalive)
     client.loop_forever()
@@ -186,27 +182,37 @@ def single(topic, payload=None, qos=0, retain=False, hostname="localhost",
 
     topic : the only required argument must be the topic string to which the
             payload will be published.
+
     payload : the payload to be published. If "" or None, a zero length payload
               will be published.
+
     qos : the qos to use when publishing,  default to 0.
+
     retain : set the message to be retained (True) or not (False).
+
     hostname : a string containing the address of the broker to connect to.
                Defaults to localhost.
+
     port : the port to connect to the broker on. Defaults to 1883.
+
     client_id : the MQTT client id to use. If "" or None, the Paho library will
                 generate a client id automatically.
+
     keepalive : the keepalive timeout value for the client. Defaults to 60
                 seconds.
+
     will : a dict containing will parameters for the client: will = {'topic':
            "<topic>", 'payload':"<payload">, 'qos':<qos>, 'retain':<retain>}.
            Topic is required, all other parameters are optional and will
            default to None, 0 and False respectively.
            Defaults to None, which indicates no will should be used.
+
     auth : a dict containing authentication parameters for the client:
            auth = {'username':"<username>", 'password':"<password>"}
            Username is required, password is optional and will default to None
            if not provided.
            Defaults to None, which indicates no authentication is to be used.
+
     tls : a dict containing TLS configuration parameters for the client:
           dict = {'ca_certs':"<ca_certs>", 'certfile':"<certfile>",
           'keyfile':"<keyfile>", 'tls_version':"<tls_version>",
@@ -215,6 +221,9 @@ def single(topic, payload=None, qos=0, retain=False, hostname="localhost",
           default to None if not provided, which results in the client using
           the default behaviour - see the paho.mqtt.client documentation.
           Defaults to None, which indicates that TLS should not be used.
+          Alternatively, tls input can be an SSLContext object, which will be
+          processed using the tls_set_context method.
+
     transport : set to "tcp" to use the default setting of transport which is
           raw TCP. Set to "websockets" to use WebSockets as the transport.
     """

--- a/src/paho/mqtt/subscribe.py
+++ b/src/paho/mqtt/subscribe.py
@@ -112,7 +112,10 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
           ca_certs is required, all other parameters are optional and will
           default to None if not provided, which results in the client using
           the default behaviour - see the paho.mqtt.client documentation.
+          Alternatively, tls input can be an SSLContext object, which will be
+          processed using the tls_set_context method.
           Defaults to None, which indicates that TLS should not be used.
+
     transport : set to "tcp" to use the default setting of transport which is
           raw TCP. Set to "websockets" to use WebSockets as the transport.
     """
@@ -157,25 +160,11 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
         client.will_set(will_topic, will_payload, will_qos, will_retain)
 
     if tls is not None:
-        ca_certs = tls['ca_certs']
-        try:
-            certfile = tls['certfile']
-        except KeyError:
-            certfile = None
-        try:
-            keyfile = tls['keyfile']
-        except KeyError:
-            keyfile = None
-        try:
-            tls_version = tls['tls_version']
-        except KeyError:
-            tls_version = ssl.PROTOCOL_SSLv23;
-        try:
-            ciphers = tls['ciphers']
-        except KeyError:
-            ciphers = None
-        client.tls_set(ca_certs, certfile, keyfile, tls_version=tls_version,
-                       ciphers=ciphers)
+        if isinstance(tls, dict):
+            client.tls_set(**tls)
+        else:
+            # Assume input is SSLContext object
+            client.tls_set_context(tls)
 
     client.connect(hostname, port, keepalive)
     client.loop_forever()
@@ -235,7 +224,10 @@ def simple(topics, qos=0, msg_count=1, retained=True, hostname="localhost", port
           ca_certs is required, all other parameters are optional and will
           default to None if not provided, which results in the client using
           the default behaviour - see the paho.mqtt.client documentation.
+          Alternatively, tls input can be an SSLContext object, which will be
+          processed using the tls_set_context method.
           Defaults to None, which indicates that TLS should not be used.
+
     transport : set to "tcp" to use the default setting of transport which is
           raw TCP. Set to "websockets" to use WebSockets as the transport.
     """

--- a/test/lib/context.py
+++ b/test/lib/context.py
@@ -52,6 +52,6 @@ def check_ssl():
         print("WARNING: SSL not available in current environment")
         exit(0)
 
-    if sys.version < '2.7':
-        print("WARNING: SSL not supported on Python 2.6")
+    if not hasattr(ssl, 'SSLContext'):
+        print("WARNING: SSL without SSLContext is not supported")
         exit(0)

--- a/test/lib/python/08-ssl-bad-cacert.test
+++ b/test/lib/python/08-ssl-bad-cacert.test
@@ -9,7 +9,7 @@ from struct import *
 
 import paho.mqtt.client as mqtt
 
-if sys.version < '2.7':
+if sys.version_info < (2, 7, 9):
     print("WARNING: SSL/TLS not supported on Python 2.6")
     exit(0)
 

--- a/test/lib/python/08-ssl-connect-cert-auth.test
+++ b/test/lib/python/08-ssl-connect-cert-auth.test
@@ -9,7 +9,7 @@ from struct import *
 
 import paho.mqtt.client as mqtt
 
-if sys.version_info < (2, 7):
+if sys.version_info < (2, 7, 9):
     print("WARNING: SSL/TLS not supported on Python 2.6")
     exit(0)
 

--- a/test/lib/python/08-ssl-connect-no-auth.test
+++ b/test/lib/python/08-ssl-connect-no-auth.test
@@ -9,7 +9,7 @@ from struct import *
 
 import paho.mqtt.client as mqtt
 
-if sys.version_info < (2, 7):
+if sys.version_info < (2, 7, 9):
     print("WARNING: SSL/TLS not supported on Python 2.6")
     exit(0)
 

--- a/test/lib/python/08-ssl-fake-cacert.test
+++ b/test/lib/python/08-ssl-fake-cacert.test
@@ -10,7 +10,7 @@ import ssl
 
 import paho.mqtt.client as mqtt
 
-if sys.version_info < (2, 7):
+if sys.version_info < (2, 7, 9):
     print("WARNING: SSL/TLS not supported on Python 2.6")
     exit(0)
 


### PR DESCRIPTION
Use SSLContext objects, if available, since this provides more options and features including SNI (#11). Also, allows default system context from `ssl.create_default_context()` to be used, improves encapsulation and supports dependency injection. 

**Update**: Removed support for SSL without SSLContext (#115)
