### PR TITLE
Handle cases where socket has been remotely closed.

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1738,6 +1738,8 @@ class Client(object):
                     print(err)
                     return 1
                 else:
+                    if len(byte) == 0:
+                        return 1
                     byte = struct.unpack("!B", byte)
                     byte = byte[0]
                     self._in_packet['remaining_count'].append(byte)
@@ -1769,6 +1771,8 @@ class Client(object):
                 print(err)
                 return 1
             else:
+                if len(data) == 0:
+                    return 1
                 self._in_packet['to_process'] = self._in_packet['to_process'] - len(data)
                 self._in_packet['packet'] = self._in_packet['packet'] + data
 


### PR DESCRIPTION
Bug 498234
Two additions to _packet_read which checks for a socket that has been closed on the other end.
Signed-off-by: Jeffrey Jasper <jeffrey.jasper@gmail.com>