### PR TITLE
Fix issue with WebSocket connection

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -143,6 +143,11 @@ if sys.version_info[0] < 3:
 else:
     sockpair_data = b"0"
 
+
+class WebsocketConnectionError(ValueError):
+    pass
+
+
 def error_string(mqtt_errno):
     """Return the error string associated with an mqtt error number."""
     if mqtt_errno == MQTT_ERR_SUCCESS:
@@ -839,8 +844,10 @@ class Client(object):
 
         if self._transport == "websockets":
             if self._tls_ca_certs is not None:
+                self._ssl.settimeout(self._keepalive)
                 self._ssl = WebsocketWrapper(self._ssl, self._host, self._port, True)
             else:
+                sock.settimeout(self._keepalive)
                 sock = WebsocketWrapper(sock, self._host, self._port, False)
 
         self._sock = sock
@@ -1375,7 +1382,7 @@ class Client(object):
             if self._state == mqtt_cs_connect_async:
                 try:
                     self.reconnect()
-                except socket.error:
+                except (socket.error, WebsocketConnectionError):
                     if not retry_first_connection:
                         raise
                     self._easy_log(MQTT_LOG_DEBUG, "Connection failed, retrying")
@@ -1416,7 +1423,7 @@ class Client(object):
                     self._state_mutex.release()
                     try:
                         self.reconnect()
-                    except socket.error as err:
+                    except (socket.error, WebsocketConnectionError) as err:
                         pass
 
         return rc
@@ -2727,7 +2734,7 @@ class WebsocketWrapper:
                     # check upgrade
                     if b"connection" in str(self._readbuffer).lower().encode('utf-8'):
                         if b"upgrade" not in str(self._readbuffer).lower().encode('utf-8'):
-                            raise ValueError("WebSocket handshake error, connection not upgraded")
+                            raise WebsocketConnectionError("WebSocket handshake error, connection not upgraded")
                         else:
                             has_upgrade = True
 
@@ -2743,7 +2750,7 @@ class WebsocketWrapper:
                         client_hash = base64.b64encode(client_hash.digest())
 
                         if server_hash != client_hash:
-                            raise ValueError("WebSocket handshake error, invalid secret key")
+                            raise WebsocketConnectionError("WebSocket handshake error, invalid secret key")
                         else:
                             has_secret = True
                 else:
@@ -2755,10 +2762,10 @@ class WebsocketWrapper:
 
             # connection reset
             elif not byte:
-                raise ValueError("WebSocket handshake error")
+                raise WebsocketConnectionError("WebSocket handshake error")
 
         if not has_upgrade or not has_secret:
-            raise ValueError("WebSocket handshake error")
+            raise WebsocketConnectionError("WebSocket handshake error")
 
         self._readbuffer = bytearray()
         self.connected = True


### PR DESCRIPTION
Avoid WebSocket handshake to hang forever. This is very similar to #90 : if due to some network condition the TCP socket hang, the WebSocket handshake will also hang.
Like for #90, it use keepalive as timeout.


If WebSocket handshake fail, loop_forever will no longer terminate but retry handshake (like it does for any other network errors). This especially occur if you have a proxy before MQTT broker (for example an HAproxy, I think any proxy that accept TCP connection while broker is down will cause the issue) but your MQTT broker is down.



To reproduce, I use a mqtt client:
```
#myclient.py
from paho.mqtt.client import Client

client = Client(transport='websockets')
client.connect_async('localhost', 8080)
client.loop_forever()
```
With a Mosquitto server with the following configuration:
```
#myconfig.conf
listener 18080
protocol websockets
```
And a proxy that accept connection. I use socat:
```
socat TCP-LISTEN:8080,fork,reuseaddr TCP:127.0.0.1:18080
```

The following step produce the error:
* Start mosquitto ```./src/mosquitto -v -c myconfig.conf``` and the socat proxy
* Start the client, it will connect correctly
* Stop the mosquitto server
* When client will retry to connect, the will crash with the following error

The errors is:
```
Traceback (most recent call last):
  File "myclient.py", line 5, in <module>
    client.loop_forever()
  File "/home/pierref/dev/ext/paho.mqtt.python/src/paho/mqtt/client.py", line 1407, in loop_forever
    self.reconnect()
  File "/home/pierref/dev/ext/paho.mqtt.python/src/paho/mqtt/client.py", line 833, in reconnect
    sock = WebsocketWrapper(sock, self._host, self._port, False)
  File "/home/pierref/dev/ext/paho.mqtt.python/src/paho/mqtt/client.py", line 2663, in __init__
    self._do_handshake()
  File "/home/pierref/dev/ext/paho.mqtt.python/src/paho/mqtt/client.py", line 2734, in _do_handshake
    raise ValueError("WebSocket handshake error")
ValueError: WebSocket handshake error

```