### PR TITLE
Prevent "list index out of range" when using wildcard certificates

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2624,9 +2624,9 @@ class Client(object):
             if cert_host.count("*") != 1:
                 return False
 
-            host_match = host.split(".", 1)[1]
-            cert_match = cert_host.split(".", 1)[1]
-            if host_match == cert_match:
+            host_match = host.split(".", 1)
+            cert_match = cert_host.split(".", 1)
+            if len(host_match) == 2 and len(cert_match) == 2 and host_match[1] == cert_match[1]:
                 return True
             else:
                 return False


### PR DESCRIPTION
If I have a wildcard certificate (e.g., cert_host=`*.localhost`), the wildcard handler tries to split hostname.
Currently, if the hostname doesn't have a dot (e.g., hostname=`localhost`), it crashes with `list index out of range`

This patch adds an extra check to prevent this error.

Yes, having host=`localhost`, cert_host=`*.localhost` will eventually fail with `ssl.SSLError: ('Certificate subject does not match remote hostname.',)`, which is the correct error

The complete error:

```
Traceback (most recent call last):
  File "tester.py", line 995, in <module>
    for instance in timeline.instances: instance.upload(dry_run=save_only)  # After 30 minutes, let each app upload its data
  File "tester.py", line 331, in upload
    publish_message(full_packet.getvalue(), dry_run=dry_run)
  File "tester.py", line 128, in publish_message
    hostname=config['mqtt_host'], port=int(config['mqtt_port']), tls=tls_conf)
  File "/home/paulo/iperlane/ipercron-utils/tester/paho/mqtt/publish.py", line 223, in single
    multiple([msg], hostname, port, client_id, keepalive, will, auth, tls, protocol, transport)
  File "/home/paulo/iperlane/ipercron-utils/tester/paho/mqtt/publish.py", line 174, in multiple
    client.connect(hostname, port, keepalive)
  File "/home/paulo/iperlane/ipercron-utils/tester/paho/mqtt/client.py", line 686, in connect
    return self.reconnect()
  File "/home/paulo/iperlane/ipercron-utils/tester/paho/mqtt/client.py", line 825, in reconnect
    self._tls_match_hostname()
  File "/home/paulo/iperlane/ipercron-utils/tester/paho/mqtt/client.py", line 2628, in _tls_match_hostname
    if self._host_matches_cert(self._host.lower(), value.lower()) == True:
  File "/home/paulo/iperlane/ipercron-utils/tester/paho/mqtt/client.py", line 2588, in _host_matches_cert
    host_match = host.split(".", 1)[1]
IndexError: list index out of range
```
