### PR TITLE
Fix publish.single/multiple if client reconnect

### DIFF
--- a/src/paho/mqtt/publish.py
+++ b/src/paho/mqtt/publish.py
@@ -50,9 +50,7 @@ def _do_publish(c):
 
 def _on_connect(c, userdata, flags, rc):
     """Internal callback"""
-    if rc == 0:
-        _do_publish(c)
-    else:
+    if rc != 0:
         raise mqtt.MQTTException(paho.connack_string(rc))
 
 
@@ -172,6 +170,7 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
                        ciphers=ciphers)
 
     client.connect(hostname, port, keepalive)
+    _do_publish(client)
     client.loop_forever()
 
 


### PR DESCRIPTION
During publish.single or publish.multiple, If the client reconnect (for example network error during the publishing of message) we will call _do_publish (and then _userdata.pop()) unconditionally:
- even if their is no more message (=> raise IndexError and crash)
- and previous message won't be published (code assume that we pop() the next message when previous was published).

Change code to no longer call _do_publish in on_connect callback, but only in on_publish callback. To initiate the loop, explicitly call _do_publish just before staring the loop_forever.
