### PR TITLE
Fix merge of PR 81 (#120)

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -70,9 +70,11 @@ MQTTv311 = 4
 PROTOCOL_NAMEv31 = "MQIsdp"
 PROTOCOL_NAMEv311 = "MQTT"
 
-# define some alias for python2 compatibility
-unicode = str
-basestring = str
+
+if sys.version_info[0] >= 3:
+    # define some alias for python2 compatibility
+    unicode = str
+    basestring = str
 
 
 # Message types


### PR DESCRIPTION
When merging #81, a error was introduced: "unicode" and "basestr" should only be defined for Python3, not for Python2.

Adding in https://github.com/eclipse/paho.mqtt.python/pull/81/commits/5cc9a6e8315938de2f91c0fc579b40463e4215c3#diff-4a46a5c4a966dc0a99d64a4fe2843dc7R74

But in the merge result, that are always defined.

The PR re-add a sys.version_info test to define them only in Python3
