### PR TITLE
Fix uninitialized variable in Websocket _recv_impl

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2836,6 +2836,7 @@ class WebsocketWrapper:
             self._readbuffer_head = 0
 
             result = None
+            payload = bytearray()
 
             chunk_startindex = self._payload_head
             chunk_endindex = self._payload_head + length


### PR DESCRIPTION
This is the fix for #126.

It use bytearray() as initial value for payload (and not empty string  "") since payload is normally a bytearray().

As I didn't known how to produce OPCODE_CONNCLOSE using Mosquitto, I've used a dummy tornado Websocket server that just close Websocket:
```
import tornado.websocket
import tornado.ioloop
class EchoWebSocket(tornado.websocket.WebSocketHandler):
    def open(self):
        self.close()
    def on_message(self, *args, **kwargs):
        pass

def make_app():
    return tornado.web.Application([
        (r"/mqtt", EchoWebSocket),
    ])

app = make_app()
app.listen(8888)
tornado.ioloop.IOLoop.current().start()
```

Then a client connection to this server fail with the UnboundLocalError & stack from #126 :+1: 
```
>>> import paho.mqtt.client
>>> cl = paho.mqtt.client.Client(transport='websockets')
>>> cl.connect('127.0.0.1', 8888)
>>> cl.loop_forever()
Traceback (most recent call last):
[...]
  File "/home/pierref/dev/ext/github.com/eclipse/paho.mqtt.python/src/paho/mqtt/client.py", line 2893, in _recv_impl
    frame = self._create_frame(WebsocketWrapper.OPCODE_CONNCLOSE, payload, 0)
UnboundLocalError: local variable 'payload' referenced before assignment
```