### PR TITLE
Detect higest TLS versions since Python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,7 +232,7 @@ tls_set()
 ::
 
     tls_set(ca_certs=None, certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED,
-        tls_version=ssl.PROTOCOL_TLSv1, ciphers=None)
+        tls_version=ssl.PROTOCOL_TLS, ciphers=None)
 
 Configure network encryption and authentication options. Enables SSL/TLS support.
 
@@ -246,7 +246,7 @@ cert_reqs
     defines the certificate requirements that the client imposes on the broker. By default this is ``ssl.CERT_REQUIRED``, which means that the broker must provide a certificate. See the ssl pydoc for more information on this parameter.
 
 tls_version
-    specifies the version of the SSL/TLS protocol to be used. By default TLS v1 is used. Previous versions (all versions beginning with SSL) are possible but not recommended due to possible security problems.
+    specifies the version of the SSL/TLS protocol to be used. By default (if the python version supports it) the highest TLS version is detected. If unavailable, TLS v1 is used. Previous versions (all versions beginning with SSL) are possible but not recommended due to possible security problems.
 
 ciphers
     a string specifying which encryption ciphers are allowable for this connection, or ``None`` to use the defaults. See the ssl pydoc for more information.

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -641,6 +641,9 @@ class Client(object):
         # Create SSLContext object
         if tls_version is None:
             tls_version = ssl.PROTOCOL_TLSv1
+            # If the python version supports it, use highest TLS version automatically
+            if hasattr(ssl, "PROTOCOL_TLS"):
+                tls_version = ssl.PROTOCOL_TLS
         context = ssl.SSLContext(tls_version)
 
         # Configure context

--- a/test/paho_test.py
+++ b/test/paho_test.py
@@ -20,12 +20,16 @@ def create_server_socket_ssl(*args, **kwargs):
     if ssl is None:
         raise RuntimeError
 
+    ssl_version = ssl.PROTOCOL_TLSv1
+    if hasattr(ssl, "PROTOCOL_TLS"):
+        ssl_version = ssl.PROTOCOL_TLS
+
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     ssock = ssl.wrap_socket(
         sock, ca_certs="../ssl/all-ca.crt",
         keyfile="../ssl/server.key", certfile="../ssl/server.crt",
-        server_side=True, ssl_version=ssl.PROTOCOL_TLSv1, **kwargs)
+        server_side=True, ssl_version=ssl_version, **kwargs)
     ssock.settimeout(10)
     ssock.bind(('', 1888))
     ssock.listen(5)


### PR DESCRIPTION
See https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS

Since Python 3.6, this constant can auto detect TLS version, and thus automatically choose TLSv1.2 or higher if applicable, instead of hardcoded TLSv1.0.

The reason behind this change is that most people won't call `set_tls` in implementation.