### PR TITLE
Make auth dict handling a bit more leniant

### DIFF
--- a/src/paho/mqtt/publish.py
+++ b/src/paho/mqtt/publish.py
@@ -130,8 +130,14 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
     client.on_publish = _on_publish
     client.on_connect = _on_connect
 
-    if auth is not None:
-        client.username_pw_set(**auth)
+    if auth:
+        username = auth.get('username')
+        if username:
+            password = auth.get('password')
+            client.username_pw_set(username, password)
+        else:
+            raise KeyError("The 'username' key was not found, this is "
+                           "required for auth")
 
     if will is not None:
         client.will_set(**will)

--- a/src/paho/mqtt/subscribe.py
+++ b/src/paho/mqtt/subscribe.py
@@ -133,8 +133,14 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
     client.on_message = _on_message_callback
     client.on_connect = _on_connect
 
-    if auth is not None:
-        client.username_pw_set(**auth)
+    if auth:
+        username = auth.get('username')
+        if username:
+            password = auth.get('password')
+            client.username_pw_set(username, password)
+        else:
+            raise KeyError("The 'username' key was not found, this is "
+                           "required for auth")
 
     if will is not None:
         client.will_set(**will)


### PR DESCRIPTION
This commit changes the logic slightly on handling of the auth dict that
gets passed in to publish or subscribe methods. Previously they expected
None to always be what is passed in which was the default. However if an
empty dict was passed in this would fail with a KeyError. Additionally
the same was true if you pased a dict in without a username key. To make
this a bit more forgiving this changes the logic so if an object is
passed in that evaluates to False (like an empty dict) the object isn't
used. It also makes checking for the presence of 'username' and
'password' use the get() method so we don't raise blank Exceptions and
are a bit more explicit in usage.

This should be fully backwards compatible with any previous usage, but
hopefully make it a bit simpler for people playing with the lib for the
first time.

Signed-off-by: Matthew Treinish <mtreinish@kortar.org>