### PR TITLE
Make test suite a bit more strict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [aliases]
 test=pytest
+[tool:pytest]
+addopts=-r xs --pylama
+strict=True
+testpaths=tests src
+[pylama]
+linters=pyflakes
+skip=tests/*

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst', 'rb') as readme_file:
     readme = readme_file.read().decode('utf-8')
 
 requirements = []
-test_requirements = ['pytest']
+test_requirements = ['pytest', 'pylama']
 setup_requirements = ['pytest-runner']
 
 if sys.version_info < (3, 0):


### PR DESCRIPTION
Because there is no linter currently run it is possible to push code that passes all the tests but will break when somebody actually tries to use it (eg. by modifying a method that is not covered by tests). This just adds pylama as a linter which is run at the same time as pytest.

I used pylama because it can be made to use pyflakes, pylint, etc., however only pyflakes is enabled for now because making the code pass pylint checks would require quite a lot of code changes. A different pull request in future could fix the pylint errors and just add the option in setup.cfg to enable it in pylama. The same applies to pep8 checking, code complexity checking, etc.