### PR TITLE
Add exponential reconnection delay

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -14,6 +14,7 @@ v1.3.x - 2017-xx-xx
 - Allow arbitrary Websocket headers and path.
   Closes #169.
 - Fix issue with large inbound payload over Websocket. Closes #107.
+- Add exponential delay for reconnection. Closes #195.
 - Move unit tests to pytest (#164) and tox (#187)
 - Add support for standard Python logging. Closes #95.
 

--- a/README.rst
+++ b/README.rst
@@ -383,6 +383,23 @@ retain
 Raises a ``ValueError`` if ``qos`` is not 0, 1 or 2, or if ``topic`` is
 ``None`` or has zero string length.
 
+reconnect_delay_set
+'''''''''''''''''''
+
+::
+
+    reconnect_delay_set(min_delay=1, max_delay=120)
+
+The client will automatically retry connection. Between each attempt
+it will wait a number of seconds between ``min_delay`` and ``max_delay``.
+
+When the connection is lost, initially the reconnection attempt is delayed of
+``min_delay`` seconds. It's doubled between subsequent attempt up to ``max_delay``.
+
+The delay is reset to ``min_delay`` when the connection complete (e.g. the CONNACK is
+received, not just the TCP connection is established).
+
+
 Connect / reconnect / disconnect
 ````````````````````````````````
 


### PR DESCRIPTION
This avoid the client to hammering the server.

The default start with 1 seconds, 2, 4, ... 120 seconds. It is configurable using reconnect_delay_set().