### PR TITLE
Fix duplicate callback on qos2 (#194)

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -367,6 +367,16 @@ class MQTTMessage:
         self.retain = False
         self.info = MQTTMessageInfo(mid)
 
+    def __eq__(self, other):
+        """Override the default Equals behavior"""
+        if isinstance(other, self.__class__):
+            return self.mid == other.mid
+        return False
+
+    def __ne__(self, other):
+        """Define a non-equality test"""
+        return not self.__eq__(other)
+
     @property
     def topic(self):
         if sys.version_info[0] >= 3:
@@ -2471,7 +2481,8 @@ class Client(object):
             rc = self._send_pubrec(message.mid)
             message.state = mqtt_ms_wait_for_pubrel
             self._in_message_mutex.acquire()
-            self._in_messages.append(message)
+            if message not in self._in_messages:
+                self._in_messages.append(message)
             self._in_message_mutex.release()
             return rc
         else:


### PR DESCRIPTION
Verify if the message isn't already in the list before adding it (qos 2).
Messages with the same mid are considered equal.