### PR TITLE
Don't require pytest-runner for package build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ with open('README.rst', 'rb') as readme_file:
 
 requirements = []
 test_requirements = ['pytest', 'pylama']
-setup_requirements = ['pytest-runner']
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+setup_requirements = ['pytest-runner'] if needs_pytest else []
 
 if sys.version_info < (3, 0):
     test_requirements += ['mock']


### PR DESCRIPTION
This PR use the code sample from https://github.com/pytest-dev/pytest-runner#conditional-requirement
It make pytest-runner only needed for running test, no longer for building package.

It was done to ease packaging of paho-mqtt on older distribution. We do package paho-mqtt as .deb on trusty and pytest-runner is hard to backport (depends on python-setuptools-scm which required a newer debhelper).