### PR TITLE
Fix reconnect_delay_set

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -838,7 +838,7 @@ class Client(object):
         """
         with self._reconnect_delay_mutex:
             self._reconnect_min_delay = min_delay
-            self._reconnect_max_delay = min_delay
+            self._reconnect_max_delay = max_delay
             self._reconnect_delay = None
 
     def reconnect(self):


### PR DESCRIPTION
Sorry if I am missing something in the code or if I don't have a good understanding of MQTT. Previously `self._reconnect_max_delay` was set to `min_delay` when `reconnect_delay_set` was called. Now `self._reconnect_max_delay` is set to `max_delay`.