### PR TITLE
Add clean_session to callback and simple subscribers

### DIFF
--- a/src/paho/mqtt/subscribe.py
+++ b/src/paho/mqtt/subscribe.py
@@ -64,7 +64,8 @@ def _on_message_simple(client, userdata, message):
 
 def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
              port=1883, client_id="", keepalive=60, will=None, auth=None,
-             tls=None, protocol=paho.MQTTv311, transport="tcp"):
+             tls=None, protocol=paho.MQTTv311, transport="tcp",
+             clean_session=True):
     """Subscribe to a list of topics and process them in a callback function.
 
     This function creates an MQTT client, connects to a broker and subscribes
@@ -117,6 +118,13 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
 
     transport : set to "tcp" to use the default setting of transport which is
           raw TCP. Set to "websockets" to use WebSockets as the transport.
+
+    clean_session : a boolean that determines the client type. If True,
+                    the broker will remove all information about this client
+                    when it disconnects. If False, the client is a persistent
+                    client and subscription information and queued messages
+                    will be retained when the client disconnects.
+                    Defaults to True.
     """
 
     if qos < 0 or qos > 2:
@@ -129,7 +137,8 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
         'userdata':userdata}
 
     client = paho.Client(client_id=client_id, userdata=callback_userdata,
-                         protocol=protocol, transport=transport)
+                         protocol=protocol, transport=transport,
+                         clean_session=clean_session)
     client.on_message = _on_message_callback
     client.on_connect = _on_connect
 
@@ -158,7 +167,8 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
 
 def simple(topics, qos=0, msg_count=1, retained=True, hostname="localhost",
            port=1883, client_id="", keepalive=60, will=None, auth=None,
-           tls=None, protocol=paho.MQTTv311, transport="tcp"):
+           tls=None, protocol=paho.MQTTv311, transport="tcp",
+           clean_session=True):
     """Subscribe to a list of topics and return msg_count messages.
 
     This function creates an MQTT client, connects to a broker and subscribes
@@ -216,6 +226,13 @@ def simple(topics, qos=0, msg_count=1, retained=True, hostname="localhost",
 
     transport : set to "tcp" to use the default setting of transport which is
           raw TCP. Set to "websockets" to use WebSockets as the transport.
+
+    clean_session : a boolean that determines the client type. If True,
+                    the broker will remove all information about this client
+                    when it disconnects. If False, the client is a persistent
+                    client and subscription information and queued messages
+                    will be retained when the client disconnects.
+                    Defaults to True.
     """
 
     if msg_count < 1:
@@ -231,6 +248,7 @@ def simple(topics, qos=0, msg_count=1, retained=True, hostname="localhost",
     userdata = {'retained':retained, 'msg_count':msg_count, 'messages':messages}
 
     callback(_on_message_simple, topics, qos, userdata, hostname, port,
-             client_id, keepalive, will, auth, tls, protocol, transport)
+             client_id, keepalive, will, auth, tls, protocol, transport,
+             clean_session)
 
     return userdata['messages']


### PR DESCRIPTION
The `clean_session` option for a Client was not exposed in `subscribe.callback` and `subscribe.simple`. This adds that option for both of these functions.