### PR TITLE
Allow resetting the username back to None

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1199,7 +1199,7 @@ class Client(object):
         """
 
         # [MQTT-3.1.3-11] User name must be UTF-8 encoded string
-        self._username = username.encode('utf-8')
+        self._username = None if username is None else username.encode('utf-8')
         self._password = password
         if isinstance(self._password, unicode):
             self._password = self._password.encode('utf-8')


### PR DESCRIPTION
In client.py, update username_pw_set() to allow resetting the username back to None.