### PR TITLE
Fix websocket payload length encoding

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2805,7 +2805,7 @@ class WebsocketWrapper(object):
         if length < 126:
             header.append(mask_flag << 7 | length)
 
-        elif length < 32768:
+        elif length < 65536:
             header.append(mask_flag << 7 | 126)
             header += struct.pack("!H", length)
 


### PR DESCRIPTION
The spec says that the payload encoding MUST be the smallest
possible. As we can encode anything in [127;65536] in 16 bits (the 7 +
16 bit case in the spec, page 29), we should do this instead of
encoding [32768;max] using 64 bits.

I added a comment in the maybe related issue: https://github.com/eclipse/paho.mqtt.python/issues/248#issuecomment-361207407