### PR TITLE
Add bridge support

### DIFF
--- a/src/paho/mqtt/__init__.py
+++ b/src/paho/mqtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.0.dev0"
+__version__ = "1.4.1.dev0"
 
 
 class MQTTException(Exception):


### PR DESCRIPTION
Mosquito broker and RSMB support a bridge connection. 

If the client establishes a bridge connection, then the broker does not send messages sent from bridge back to the bridge thus avoiding loops. It also enables proper propagation of retain flag. With this feature, now the library can be used to create bridges between two brokers. 

This implementation adds a function that can be used to enable this feature. The function must be called before the connect function (just like set user-name and password function).

The implementation adds two global constants to identify the mode being used, and if the mode is bridge mode, then when sending the connect packet, sets the MSB of protocol version bit high (indicating a bridge connection to the broker)