### PR TITLE
Always send back a PUBCOMP

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2535,9 +2535,7 @@ class Client(object):
                         if rc != MQTT_ERR_SUCCESS:
                             return rc
 
-                    return self._send_pubcomp(mid)
-
-        return MQTT_ERR_SUCCESS
+        return self._send_pubcomp(mid)
 
     def _update_inflight(self):
         # Dont lock message_mutex here


### PR DESCRIPTION
See #284 

This may not be the most correct behavior but seems like the only way to stop a session from getting stuck forever in the specific case listed in the issue.