### PR TITLE
Always send back a PUBCOMP so things don't get stuck

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2706,9 +2706,7 @@ class Client(object):
                         if rc != MQTT_ERR_SUCCESS:
                             return rc
 
-                    return self._send_pubcomp(mid)
-
-        return MQTT_ERR_SUCCESS
+        return self._send_pubcomp(mid)
 
     def _update_inflight(self):
         # Dont lock message_mutex here


### PR DESCRIPTION
This is a quick patch to make sure we always respond to a PUBREL with a PUBCOMP so a session doesn't get stuck.

Signed-off-by: Reuben Balik <rsbalik@gmail.com>