### PR TITLE
Catch OSError in addition to socket.error and WebsocketConnectionError

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1468,7 +1468,7 @@ class Client(object):
             if self._state == mqtt_cs_connect_async:
                 try:
                     self.reconnect()
-                except (socket.error, WebsocketConnectionError):
+                except (socket.error, OSError, WebsocketConnectionError):
                     if not retry_first_connection:
                         raise
                     self._easy_log(MQTT_LOG_DEBUG, "Connection failed, retrying")


### PR DESCRIPTION
Socket library docs indicated that socket.error is an alias for OSError in Python 3 but TimeoutError is not caught. This means that the error handling in loop_forever does not catch TimeoutError when retry_first_connection=True leading to an unsreposive thread.

Signed-off-by: Mike Hales <mike.hales@kscape.com>