### PR TITLE
Properly close sockets on Client.__del__()

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -574,9 +574,9 @@ class Client(object):
         self._websocket_extra_headers = None
 
     def __del__(self):
-        pass
+        self._reset_sockets()
 
-    def reinitialise(self, client_id="", clean_session=True, userdata=None):
+    def _reset_sockets(self):
         if self._sock:
             self._sock.close()
             self._sock = None
@@ -586,6 +586,9 @@ class Client(object):
         if self._sockpairW:
             self._sockpairW.close()
             self._sockpairW = None
+
+    def reinitialise(self, client_id="", clean_session=True, userdata=None):
+        self._reset_sockets()
 
         self.__init__(client_id, clean_session, userdata)
 


### PR DESCRIPTION
As described in issue #170, the Client class does not properly close its sockets on destruction.
This PR fixes this.

Here's a minimal program demonstrating the problem:
```python
import time
import paho.mqtt.client as mqtt


def on_connect(client, userdata, flags, rc):
    print("Connected with result code "+str(rc))


def on_message(client, userdata, msg):
    print(msg.topic+" "+str(msg.payload))


def main():
    client = mqtt.Client()
    client.on_connect = on_connect
    client.on_message = on_message

    client.connect("iot.eclipse.org", 1883, 60)
    client.loop_start()
    time.sleep(1)
    client.loop_stop()
    del client


if __name__ == '__main__':
    main()
```

On the current master, if the program is executed with `python -Wall test.py` on Python 3.7, it reports the following warnings:

```
test.py:32: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.1.134', 64661), raddr=('198.41.30.241', 1883)>
  del client
test.py:32: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 64660), raddr=('127.0.0.1', 64659)>
  del client
test.py:32: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 64659), raddr=('127.0.0.1', 64660)>
  del client
```

With the proposed fix, the warnings are gone.