### PR TITLE
extended MQTTMessageInfo:wait_for_publish with a timeout

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -322,13 +322,13 @@ class MQTTMessageInfo(object):
             self._published = True
             self._condition.notify()
 
-    def wait_for_publish(self):
+    def wait_for_publish(self, timeout=None):
         """Block until the message associated with this object is published."""
         if self.rc == MQTT_ERR_QUEUE_SIZE:
             raise ValueError('Message is not queued due to ERR_QUEUE_SIZE')
         with self._condition:
             while not self._published:
-                self._condition.wait()
+                self._condition.wait(timeout)
 
     def is_published(self):
         """Returns True if the message associated with this object has been


### PR DESCRIPTION
In order to enable waiting with timeout after issuing
  mqtt.Client's publish(..) like:

```
infot = self.mqttc.publish(topic, msg, qos=1)
infot.wait_for_publish(0.5)
```
