### PR TITLE
Leave write_loop() call to socket_register_write callback if present.

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2574,7 +2574,9 @@ class Client(object):
             if err.errno != EAGAIN:
                 raise
 
-        if self._thread is None:
+        # If we have an external event loop registered, use that instead
+        # of calling lling loop_write() directly.
+        if self._thread is None and self.socket_register_write is None:
             if self._in_callback_mutex.acquire(False):
                 self._in_callback_mutex.release()
                 return self.loop_write()


### PR DESCRIPTION
Instead of calling write_loop() directly when using an external event
loop, check whether the socket_register_write callback is set, and use
it if it is available.

This fixes #361, since on_publish() is now called from the
socket_register_write_callback that runs in a different
thread/coroutine instead of by the publish() function itself.

Note that this has only been tested with the asyncio external event loop, not with other external event loops.