### PR TITLE
Add error message for MQTT_ERR_QUEUE_SIZE

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -203,6 +203,8 @@ def error_string(mqtt_errno):
         return "Unknown error."
     elif mqtt_errno == MQTT_ERR_ERRNO:
         return "Error defined by errno."
+    elif mqtt_errno == MQTT_ERR_QUEUE_SIZE:
+        return "Message queue full."
     else:
         return "Unknown error."
 


### PR DESCRIPTION
Generate a more meaningful error message when the message cannot be queued for publishing.