### PR TITLE
Add error handling around filtered callbacks

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3412,7 +3412,6 @@ class Client(object):
 
             if topic is not None:
                 for callback in self._on_message_filtered.iter_match(message.topic):
-                    self._easy_log(MQTT_LOG_INFO, f'running filtered callback: {callback}')
                     with self._in_callback_mutex:
                         try:
                             callback(self, self._userdata, message)

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3412,8 +3412,17 @@ class Client(object):
 
             if topic is not None:
                 for callback in self._on_message_filtered.iter_match(message.topic):
+                    self._easy_log(MQTT_LOG_INFO, f'running filtered callback: {callback}')
                     with self._in_callback_mutex:
-                        callback(self, self._userdata, message)
+                        try:
+                            callback(self, self._userdata, message)
+                        except Exception as err:
+                            self._easy_log(
+                                MQTT_LOG_ERR,
+                                'Caught exception in user defined callback function %s: %s',
+                                callback.__name__,
+                                err
+                            )
                     matched = True
 
             if matched == False and self.on_message:


### PR DESCRIPTION
Callbacks specified through the message_callback_add function were crashing the main thread if an exception was raised inside them.

I noticed the error handling was protecting the generic on_message callback, but the more specific per-topic callbacks were not protected against exceptions.