### PR TITLE
Add try-except around filtered callback

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3412,8 +3412,15 @@ class Client(object):
 
             if topic is not None:
                 for callback in self._on_message_filtered.iter_match(message.topic):
-                    with self._in_callback_mutex:
+                    try:
                         callback(self, self._userdata, message)
+                    except Exception as err:
+                        self._easy_log(
+                            MQTT_LOG_ERR,
+                            'Caught exception in user defined callback function %s: %s',
+                            callback.__name__,
+                            err
+                        )
                     matched = True
 
             if matched == False and self.on_message:


### PR DESCRIPTION
If an exception was raised in a filtered callback function, the main thread would crash.

Signed-off-by: Josiah Witheford <josiah.witheford@gmail.com>