### PR TITLE
Fix for sending MQTTv5 message properties when message is queued

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2834,7 +2834,8 @@ class Client(object):
                             m.payload,
                             m.qos,
                             m.retain,
-                            m.dup
+                            m.dup,
+                            properties=m.properties,
                         )
                     elif m.state == mqtt_ms_wait_for_pubrel:
                         m.timestamp = now

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3285,6 +3285,7 @@ class Client(object):
                         m.qos,
                         m.retain,
                         m.dup,
+                        properties=m.properties,
                     )
                     if rc != 0:
                         return rc


### PR DESCRIPTION
I've found that when I publish multiple messages at once with some properties attached, another client receives all the messages, but some of them arrive with properties stripped. After some digging I've found that this happens if I send more than 20 messages, which is a default value for max inflight messages.
This PR fixes that. I've also found another location in the code where properties were not published which I've also corrected in this PR.