### PR TITLE
Travis CI: Test on Python 3.7 and 3.8 drop 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
-sudo: false
-
 language: python
 
-matrix:
+jobs:
   include:
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.7
+      env: TOXENV=py37
     - python: 3.6
       env: TOXENV=py36
     - python: 3.5
       env: TOXENV=py35
-    - python: 3.4
-      env: TOXENV=py34
     - python: 2.7
       env: TOXENV=py27
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}
+envlist = py{27,35,36,37,38}
 
 [testenv]
 whitelist_externals = make


### PR DESCRIPTION
https://devguide.python.org/#status-of-python-branches
Support current version of CPython plus legacy Python 2.7.

Travis has dropped the `sudo:` tag and has replaced `matrix:` in favor of `jobs:`.