### PR TITLE
Add reconnect_on_protocol_failure argument

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -513,7 +513,7 @@ class Client(object):
     """
 
     def __init__(self, client_id="", clean_session=None, userdata=None,
-                 protocol=MQTTv311, transport="tcp"):
+                 protocol=MQTTv311, transport="tcp", reconnect_on_failure=True):
         """client_id is the unique client id string used when connecting to the
         broker. If client_id is zero length or None, then the behaviour is
         defined by which protocol version is in use. If using MQTT v3.1.1, then
@@ -600,6 +600,7 @@ class Client(object):
         self._reconnect_min_delay = 1
         self._reconnect_max_delay = 120
         self._reconnect_delay = None
+        self._reconnect_on_failure = reconnect_on_failure
         self._ping_t = 0
         self._last_mid = 0
         self._state = mqtt_cs_new
@@ -1743,14 +1744,16 @@ class Client(object):
         is useful for the case where you only want to run the MQTT client loop
         in your program.
 
-        loop_forever() will handle reconnecting for you. If you call
-        disconnect() in a callback it will return.
+        loop_forever() will handle reconnecting for you if reconnect_on_failure is
+        true (this is the default behavior). If you call disconnect() in a callback
+        it will return.
 
 
         timeout: The time in seconds to wait for incoming/outgoing network
           traffic before timing out and returning.
         max_packets: Not currently used.
         retry_first_connection: Should the first connection attempt be retried on failure.
+          This is independent of the reconnect_on_failure setting.
 
         Raises socket.error on first connection failures unless retry_first_connection=True
         """
@@ -1792,7 +1795,7 @@ class Client(object):
             def should_exit():
                 return self._state == mqtt_cs_disconnecting or run is False or self._thread_terminate is True
 
-            if should_exit():
+            if should_exit() or not self._reconnect_on_failure:
                 run = False
             else:
                 self._reconnect_wait()
@@ -2984,6 +2987,8 @@ class Client(object):
             (flags, result) = struct.unpack("!BB", self._in_packet['packet'])
         if self._protocol == MQTTv311:
             if result == CONNACK_REFUSED_PROTOCOL_VERSION:
+                if not self._reconnect_on_failure:
+                    return MQTT_ERR_PROTOCOL
                 self._easy_log(
                     MQTT_LOG_DEBUG,
                     "Received CONNACK (%s, %s), attempting downgrade to MQTT v3.1.",
@@ -2994,6 +2999,8 @@ class Client(object):
                 return self.reconnect()
             elif (result == CONNACK_REFUSED_IDENTIFIER_REJECTED
                     and self._client_id == b''):
+                if not self._reconnect_on_failure:
+                    return MQTT_ERR_PROTOCOL
                 self._easy_log(
                     MQTT_LOG_DEBUG,
                     "Received CONNACK (%s, %s), attempting to use non-empty CID",


### PR DESCRIPTION
This is a non-breaking change.

I added the argument `reconnect_on_protocol_failure` to the `Client.__init__` function. It defaults to `True`, which aligns with the current semantics. When set to `False`, paho won't try to reconnect inside `_handle_connack` (it simply returns `MQTT_ERR_PROTOCOL` instead).

---

This feature request came from a bug report in sbtinstruments/asyncio-mqtt#26. The implicit reconnect inside `handle_connack` blocks the current thread. When we use the external event loop API (as we do in asyncio-mqtt), it blocks the event loop itself. That is very bad.

We will set `reconnect_on_protocol_failure=False` in asyncio-mqtt to avoid blocking the event loop. I'd recommend all users of the external event loop API to do the same.

I'm open to renaming stuff and moving the argument to another function if you think that aligns better with the current paho API design. Let me know what you think. :+1: 