### PR TITLE
Updated MQTT sandbox broker URL.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Here is a very simple example that subscribes to the broker $SYS topic tree and 
     client.on_connect = on_connect
     client.on_message = on_message
 
-    client.connect("mqtt.eclipse.org", 1883, 60)
+    client.connect("mqtt.eclipseprojects.io", 1883, 60)
 
     # Blocking call that processes network traffic, dispatches callbacks and
     # handles reconnecting.
@@ -476,7 +476,7 @@ Connect Example
 
 .. code:: python
 
-    mqttc.connect("mqtt.eclipse.org")
+    mqttc.connect("mqtt.eclipseprojects.io")
 
 connect_async()
 '''''''''''''''
@@ -613,7 +613,7 @@ Loop Start/Stop Example
 
 .. code:: python
 
-    mqttc.connect("mqtt.eclipse.org")
+    mqttc.connect("mqtt.eclipseprojects.io")
     mqttc.loop_start()
 
     while True:
@@ -1258,7 +1258,7 @@ Publish Single Example
 
     import paho.mqtt.publish as publish
 
-    publish.single("paho/test/single", "payload", hostname="mqtt.eclipse.org")
+    publish.single("paho/test/single", "payload", hostname="mqtt.eclipseprojects.io")
 
 Multiple
 ````````
@@ -1299,7 +1299,7 @@ Publish Multiple Example
 
     msgs = [{'topic':"paho/test/multiple", 'payload':"multiple 1"},
         ("paho/test/multiple", "multiple 2", 0, False)]
-    publish.multiple(msgs, hostname="mqtt.eclipse.org")
+    publish.multiple(msgs, hostname="mqtt.eclipseprojects.io")
 
 
 Subscribe
@@ -1398,7 +1398,7 @@ Simple Example
 
     import paho.mqtt.subscribe as subscribe
 
-    msg = subscribe.simple("paho/test/simple", hostname="mqtt.eclipse.org")
+    msg = subscribe.simple("paho/test/simple", hostname="mqtt.eclipseprojects.io")
     print("%s %s" % (msg.topic, msg.payload))
 
 Using Callback
@@ -1447,7 +1447,7 @@ Callback Example
     def on_message_print(client, userdata, message):
         print("%s %s" % (message.topic, message.payload))
 
-    subscribe.callback(on_message_print, "paho/test/callback", hostname="mqtt.eclipse.org")
+    subscribe.callback(on_message_print, "paho/test/callback", hostname="mqtt.eclipseprojects.io")
 
 
 Reporting bugs

--- a/examples/client_logger.py
+++ b/examples/client_logger.py
@@ -30,7 +30,7 @@ mqttc = mqtt.Client()
 logger = logging.getLogger(__name__)
 mqttc.enable_logger(logger)
 
-mqttc.connect("mqtt.eclipse.org", 1883, 60)
+mqttc.connect("mqtt.eclipseprojects.io", 1883, 60)
 mqttc.subscribe("$SYS/#", 0)
 
 mqttc.loop_forever()

--- a/examples/client_mqtt_clear_retain.py
+++ b/examples/client_mqtt_clear_retain.py
@@ -59,7 +59,7 @@ def print_usage():
 
 def main(argv):
     debug = False
-    host = "mqtt.eclipse.org"
+    host = "mqtt.eclipseprojects.io"
     client_id = None
     keepalive = 60
     port = 1883

--- a/examples/client_pub-wait.py
+++ b/examples/client_pub-wait.py
@@ -53,7 +53,7 @@ mqttc.on_publish = on_publish
 mqttc.on_subscribe = on_subscribe
 # Uncomment to enable debug messages
 # mqttc.on_log = on_log
-mqttc.connect("mqtt.eclipse.org", 1883, 60)
+mqttc.connect("mqtt.eclipseprojects.io", 1883, 60)
 
 mqttc.loop_start()
 

--- a/examples/client_pub_opts.py
+++ b/examples/client_pub_opts.py
@@ -23,7 +23,7 @@ import time
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument('-H', '--host', required=False, default="mqtt.eclipse.org")
+parser.add_argument('-H', '--host', required=False, default="mqtt.eclipseprojects.io")
 parser.add_argument('-t', '--topic', required=False, default="paho/test/opts")
 parser.add_argument('-q', '--qos', required=False, type=int,default=0)
 parser.add_argument('-c', '--clientid', required=False, default=None)

--- a/examples/client_session_present.py
+++ b/examples/client_session_present.py
@@ -49,7 +49,7 @@ mqttc.on_disconnect = on_disconnect
 # Uncomment to enable debug messages
 # mqttc.on_log = on_log
 mqttc.user_data_set(0)
-mqttc.connect("mqtt.eclipse.org", 1883, 60)
+mqttc.connect("mqtt.eclipseprojects.io", 1883, 60)
 
 mqttc.loop_forever()
 
@@ -57,5 +57,5 @@ mqttc.loop_forever()
 mqttc = mqtt.Client(client_id="asdfj", clean_session=True)
 mqttc.on_connect = on_connect
 mqttc.user_data_set(2)
-mqttc.connect("mqtt.eclipse.org", 1883, 60)
+mqttc.connect("mqtt.eclipseprojects.io", 1883, 60)
 mqttc.loop_forever()

--- a/examples/client_sub-class.py
+++ b/examples/client_sub-class.py
@@ -36,7 +36,7 @@ class MyMQTTClass(mqtt.Client):
         print(string)
 
     def run(self):
-        self.connect("mqtt.eclipse.org", 1883, 60)
+        self.connect("mqtt.eclipseprojects.io", 1883, 60)
         self.subscribe("$SYS/#", 0)
 
         rc = 0

--- a/examples/client_sub-multiple-callback.py
+++ b/examples/client_sub-multiple-callback.py
@@ -46,7 +46,7 @@ mqttc = mqtt.Client()
 mqttc.message_callback_add("$SYS/broker/messages/#", on_message_msgs)
 mqttc.message_callback_add("$SYS/broker/bytes/#", on_message_bytes)
 mqttc.on_message = on_message
-mqttc.connect("mqtt.eclipse.org", 1883, 60)
+mqttc.connect("mqtt.eclipseprojects.io", 1883, 60)
 mqttc.subscribe("$SYS/#", 0)
 
 mqttc.loop_forever()

--- a/examples/client_sub.py
+++ b/examples/client_sub.py
@@ -52,7 +52,7 @@ mqttc.on_publish = on_publish
 mqttc.on_subscribe = on_subscribe
 # Uncomment to enable debug messages
 # mqttc.on_log = on_log
-mqttc.connect("mqtt.eclipse.org", 1883, 60)
+mqttc.connect("mqtt.eclipseprojects.io", 1883, 60)
 mqttc.subscribe("$SYS/#", 0)
 
 mqttc.loop_forever()

--- a/examples/client_sub_opts.py
+++ b/examples/client_sub_opts.py
@@ -22,7 +22,7 @@ import argparse
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument('-H', '--host', required=False, default="mqtt.eclipse.org")
+parser.add_argument('-H', '--host', required=False, default="mqtt.eclipseprojects.io")
 parser.add_argument('-t', '--topic', required=False, default="$SYS/#")
 parser.add_argument('-q', '--qos', required=False, type=int, default=0)
 parser.add_argument('-c', '--clientid', required=False, default=None)

--- a/examples/loop_asyncio.py
+++ b/examples/loop_asyncio.py
@@ -85,7 +85,7 @@ class AsyncMqttExample:
 
         aioh = AsyncioHelper(self.loop, self.client)
 
-        self.client.connect('mqtt.eclipse.org', 1883, 60)
+        self.client.connect('mqtt.eclipseprojects.io', 1883, 60)
         self.client.socket().setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 2048)
 
         for c in range(3):

--- a/examples/loop_select.py
+++ b/examples/loop_select.py
@@ -64,7 +64,7 @@ class SelectMqttExample:
         self.client.on_message = self.on_message
         self.client.on_disconnect = self.on_disconnect
 
-        self.client.connect('mqtt.eclipse.org', 1883, 60)
+        self.client.connect('mqtt.eclipseprojects.io', 1883, 60)
         print("Socket opened")
         self.client.socket().setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 2048)
 

--- a/examples/loop_trio.py
+++ b/examples/loop_trio.py
@@ -77,7 +77,7 @@ class TrioAsyncMqttExample:
 
         trio_helper = TrioAsyncHelper(self.client)
 
-        self.client.connect('mqtt.eclipse.org', 1883, 60)
+        self.client.connect('mqtt.eclipseprojects.io', 1883, 60)
 
         async with trio.open_nursery() as nursery:
             nursery.start_soon(trio_helper.read_loop)

--- a/examples/publish_multiple.py
+++ b/examples/publish_multiple.py
@@ -19,4 +19,4 @@ import context  # Ensures paho is in PYTHONPATH
 import paho.mqtt.publish as publish
 
 msgs = [{'topic': "paho/test/multiple", 'payload': "multiple 1"}, ("paho/test/multiple", "multiple 2", 0, False)]
-publish.multiple(msgs, hostname="mqtt.eclipse.org")
+publish.multiple(msgs, hostname="mqtt.eclipseprojects.io")

--- a/examples/publish_single.py
+++ b/examples/publish_single.py
@@ -18,4 +18,4 @@
 import context  # Ensures paho is in PYTHONPATH
 import paho.mqtt.publish as publish
 
-publish.single("paho/test/single", "boo", hostname="mqtt.eclipse.org")
+publish.single("paho/test/single", "boo", hostname="mqtt.eclipseprojects.io")

--- a/examples/publish_utf8-27.py
+++ b/examples/publish_utf8-27.py
@@ -20,4 +20,4 @@ import paho.mqtt.publish as publish
 
 topic = u"paho/test/single/ô"
 payload = u"bôô"
-publish.single(topic, payload, hostname="mqtt.eclipse.org")
+publish.single(topic, payload, hostname="mqtt.eclipseprojects.io")

--- a/examples/server_rpc_math.py
+++ b/examples/server_rpc_math.py
@@ -90,6 +90,6 @@ mqttc.on_connect = on_connect
 # Uncomment to enable debug messages
 #mqttc.on_log = on_log
 
-#mqttc.connect("mqtt.eclipse.org", 1883, 60)
+#mqttc.connect("mqtt.eclipseprojects.io", 1883, 60)
 mqttc.connect(host="localhost", clean_start=False)
 mqttc.loop_forever()

--- a/examples/subscribe_callback.py
+++ b/examples/subscribe_callback.py
@@ -21,4 +21,4 @@ import paho.mqtt.subscribe as subscribe
 def print_msg(client, userdata, message):
     print("%s : %s" % (message.topic, message.payload))
 
-subscribe.callback(print_msg, "#", hostname="mqtt.eclipse.org")
+subscribe.callback(print_msg, "#", hostname="mqtt.eclipseprojects.io")

--- a/examples/subscribe_simple.py
+++ b/examples/subscribe_simple.py
@@ -20,7 +20,7 @@ import paho.mqtt.subscribe as subscribe
 
 topics = ['#']
 
-m = subscribe.simple(topics, hostname="mqtt.eclipse.org", retained=False, msg_count=2)
+m = subscribe.simple(topics, hostname="mqtt.eclipseprojects.io", retained=False, msg_count=2)
 for a in m:
     print(a.topic)
     print(a.payload)


### PR DESCRIPTION
# New features and improvements
None

# Breaking changes
None

# Bug fixes
As mentioned in #544, trying to connect to "mqtt.eclipse.org" causes a `socket.timeout: timed out`.  This URL has to be changed to "mqtt.eclipseprojects.io" in all the examples and README.

# Related issue 
Closes #544 