### PR TITLE
Travis CI: Remove unnecessary Python f-strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ jobs:
       env: TOXENV=py36
     - python: 3.5
       env: TOXENV=py35
-    - python: 2.7
-      env: TOXENV=py27
 
 install:
   - git clone https://github.com/eclipse/paho.mqtt.testing.git || true

--- a/examples/loop_trio.py
+++ b/examples/loop_trio.py
@@ -47,7 +47,7 @@ class TrioAsyncHelper:
         self._event_large_write.set()
 
     def on_socket_unregister_write(self, client, userdata, sock):
-        print(f"finished large write")
+        print("finished large write")
         self._event_large_write = trio.Event()
 
 
@@ -60,12 +60,12 @@ class TrioAsyncMqttExample:
         print("Got response with {} bytes".format(len(msg.payload)))
 
     def on_disconnect(self, client, userdata, rc):
-        print(f'Disconnect result {rc}')
+        print('Disconnect result {}'.format(rc))
 
     async def test_write(self, cancel_scope: trio.CancelScope):
         for c in range(3):
             await trio.sleep(5)
-            print(f"Publishing")
+            print("Publishing")
             self.client.publish(topic, b'Hello' * 40000, qos=1)
         cancel_scope.cancel()
 


### PR DESCRIPTION
These Python f-strings are not necessary and are breaking Travis CI jobs.
https://travis-ci.org/github/eclipse/paho.mqtt.python/pull_requests