### PR TITLE
Updated documentation: max message queue size

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -249,7 +249,7 @@ max_queued_messages_set()
 
 Set the maximum number of outgoing messages with QoS>0 that can be pending in the outgoing message queue.
 
-Defaults to 0. 0 means unlimited. When the queue is full, any further outgoing messages would be dropped.
+Defaults to 0. 0 means unlimited, but due to implementation currently limited to 65555. When the queue is full, any further outgoing messages would be dropped.
 
 message_retry_set()
 '''''''''''''''''''

--- a/README.rst
+++ b/README.rst
@@ -249,7 +249,7 @@ max_queued_messages_set()
 
 Set the maximum number of outgoing messages with QoS>0 that can be pending in the outgoing message queue.
 
-Defaults to 0. 0 means unlimited, but due to implementation currently limited to 65555. When the queue is full, any further outgoing messages would be dropped.
+Defaults to 0. 0 means unlimited, but due to implementation currently limited to 65555 (65535 messages in queue + 20 in flight). When the queue is full, any further outgoing messages would be dropped.
 
 message_retry_set()
 '''''''''''''''''''


### PR DESCRIPTION
I've also stumbled upon the max message queue size of 65555, see https://github.com/eclipse/paho.mqtt.python/issues/377
So unless this is fixed documentation should tell about that fact. Knowing this can save a lot of time, hassles and headache. 