### PR TITLE
Decorators to register client callback functions

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1857,6 +1857,12 @@ class Client(object):
         """
         self._on_log = func
 
+    def log_callback(self):
+        def decorator(func):
+            self.on_log = func
+            return func
+        return decorator
+
     @property
     def on_connect(self):
         """If implemented, called when the broker responds to our connection
@@ -1903,6 +1909,12 @@ class Client(object):
         with self._callback_mutex:
             self._on_connect = func
 
+    def connect_callback(self):
+        def decorator(func):
+            self.on_connect = func
+            return func
+        return decorator
+
     @property
     def on_subscribe(self):
         """If implemented, called when the broker responds to a subscribe
@@ -1933,6 +1945,12 @@ class Client(object):
         with self._callback_mutex:
             self._on_subscribe = func
 
+    def subscribe_callback(self):
+        def decorator(func):
+            self.on_subscribe = func
+            return func
+        return decorator
+
     @property
     def on_message(self):
         """If implemented, called when a message has been received on a topic
@@ -1957,6 +1975,12 @@ class Client(object):
         """
         with self._callback_mutex:
             self._on_message = func
+
+    def message_callback(self):
+        def decorator(func):
+            self.on_message = func
+            return func
+        return decorator
 
     @property
     def on_publish(self):
@@ -1984,6 +2008,12 @@ class Client(object):
         """
         with self._callback_mutex:
             self._on_publish = func
+
+    def publish_callback(self):
+        def decorator(func):
+            self.on_publish = func
+            return func
+        return decorator
 
     @property
     def on_unsubscribe(self):
@@ -2013,6 +2043,12 @@ class Client(object):
         with self._callback_mutex:
             self._on_unsubscribe = func
 
+    def unsubscribe_callback(self):
+        def decorator(func):
+            self.on_unsubscribe = func
+            return func
+        return decorator
+
     @property
     def on_disconnect(self):
         """If implemented, called when the client disconnects from the broker.
@@ -2040,6 +2076,12 @@ class Client(object):
         with self._callback_mutex:
             self._on_disconnect = func
 
+    def disconnect_callback(self):
+        def decorator(func):
+            self.on_disconnect = func
+            return func
+        return decorator
+
     @property
     def on_socket_open(self):
         """If implemented, called just after the socket was opend."""
@@ -2060,6 +2102,12 @@ class Client(object):
         """
         with self._callback_mutex:
             self._on_socket_open = func
+
+    def socket_open_callback(self):
+        def decorator(func):
+            self.on_socket_open = func
+            return func
+        return decorator
 
     def _call_socket_open(self):
         """Call the socket_open callback with the just-opened socket"""
@@ -2095,6 +2143,12 @@ class Client(object):
         with self._callback_mutex:
             self._on_socket_close = func
 
+    def socket_close_callback(self):
+        def decorator(func):
+            self.on_socket_close = func
+            return func
+        return decorator
+
     def _call_socket_close(self, sock):
         """Call the socket_close callback with the about-to-be-closed socket"""
         with self._callback_mutex:
@@ -2128,6 +2182,12 @@ class Client(object):
         """
         with self._callback_mutex:
             self._on_socket_register_write = func
+
+    def socket_register_write_callback(self):
+        def decorator(func):
+            self._on_socket_register_write = func
+            return func
+        return decorator
 
     def _call_socket_register_write(self):
         """Call the socket_register_write callback with the unwritable socket"""
@@ -2166,6 +2226,12 @@ class Client(object):
         with self._callback_mutex:
             self._on_socket_unregister_write = func
 
+    def socket_unregister_write_callback(self):
+        def decorator(func):
+            self._on_socket_unregister_write = func
+            return func
+        return decorator
+
     def _call_socket_unregister_write(self, sock=None):
         """Call the socket_unregister_write callback with the writable socket"""
         sock = sock or self._sock
@@ -2199,6 +2265,12 @@ class Client(object):
 
         with self._callback_mutex:
             self._on_message_filtered[sub] = callback
+
+    def topic_callback(self, sub):
+        def decorator(func):
+            self.message_callback_add(sub, func)
+            return func
+        return decorator
 
     def message_callback_remove(self, sub):
         """Remove a message callback previously registered with


### PR DESCRIPTION
I implemented decorators to register the callback functions in the Client class. This allows to write code like this:

```
from paho.mqtt.client import Client

host = "localhost"
client = Client()
topic = "MyTopic/SubTopic"

@client.connect_callback()
def on_connect(client, userdata, flags, rc):
    # handle the callback
    pass


@client.topic_callback(topic)
def on_subtopic(client, userdata, message):
    # handle incoming message from MyTopic/SubTopic feed
    msg = message.payload.decode()

if __name__ == '__main__':
    client.connect(host)
    client.subscribe(topic)
    client.loop_forever()
```
I think this would be a nice addition to this library. In my opinion it makes the callback handling stuff more comfortable to use. What do you think?