### PR TITLE
Error for v5 protocol in one-shot helpers

### DIFF
--- a/src/paho/mqtt/publish.py
+++ b/src/paho/mqtt/publish.py
@@ -131,6 +131,9 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
     if not isinstance(msgs, Iterable):
         raise TypeError('msgs must be an iterable')
 
+    if protocol == mqtt.client.MQTTv5:
+        raise NotImplementedError('protocol MQTTv5 not supported')
+
     client = paho.Client(client_id=client_id, userdata=collections.deque(msgs),
                          protocol=protocol, transport=transport)
 

--- a/src/paho/mqtt/subscribe.py
+++ b/src/paho/mqtt/subscribe.py
@@ -132,6 +132,9 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
     if qos < 0 or qos > 2:
         raise ValueError('qos must be in the range 0-2')
 
+    if protocol == mqtt.client.MQTTv5:
+        raise NotImplementedError('protocol MQTTv5 not supported')
+
     callback_userdata = {
         'callback':callback,
         'topics':topics,

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,16 @@
+import pytest
+
+from paho.mqtt.publish import single, multiple
+from paho.mqtt.client import MQTTv5
+
+
+class TestSingle(object):
+    def test_invalid_protocol(self):
+        with pytest.raises(NotImplementedError):
+            single("test/topic", protocol=MQTTv5)
+
+
+class TestMultiple(object):
+    def test_invalid_protocol(self):
+        with pytest.raises(NotImplementedError):
+            multiple([{"topic": "test/topic"}], protocol=MQTTv5)

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -1,0 +1,20 @@
+import pytest
+
+from paho.mqtt.subscribe import simple, callback
+from paho.mqtt.client import MQTTv5
+
+
+class TestSimple(object):
+    def test_invalid_protocol(self):
+        with pytest.raises(NotImplementedError):
+            simple("test/topic", protocol=MQTTv5)
+
+
+class TestCallback(object):
+    def test_invalid_protocol(self):
+        # Define a dummy callback
+        def on_message(client, userdata, message):
+            raise RuntimeError("This shouldn't be called")
+
+        with pytest.raises(NotImplementedError):
+            callback(on_message, ["test/topic"], protocol=MQTTv5)


### PR DESCRIPTION
# Description

Addresses #575 by introducing a `NotImplementedError` when using the one-shot helper functions (publish.single, publish.multiple, subscribe.simple, subscribe.callback) with the MQTTv5 protocol version.

# Testing

New test modules are introduced for the currently untested helper functions.

A single test is added for each function, confirming that the error is raised when the v5 protocol is supplied.

# Notes

I have followed the steps in CONTRIBUTING.md