### PR TITLE
Fix wrong usage of socket timeout

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -568,6 +568,7 @@ class Client(object):
         self._sockpairR, self._sockpairW = (None, None,)
         self._sockpairR, self._sockpairW = _socketpair_compat()
         self._keepalive = 60
+        self._connect_timeout = 5.0
         self._message_retry = 20
         self._last_retry_check = 0
         self._client_mode = MQTT_CLIENT
@@ -3537,12 +3538,12 @@ class Client(object):
         if sys.version_info < (2, 7) or (3, 0) < sys.version_info < (3, 2):
             # Have to short-circuit here because of unsupported source_address
             # param in earlier Python versions.
-            return socket.create_connection(addr, timeout=self._keepalive)
+            return socket.create_connection(addr, timeout=self._connect_timeout)
 
         if proxy:
-            return socks.create_connection(addr, source_address=source, timeout=self._keepalive, **proxy)
+            return socks.create_connection(addr, timeout=self._connect_timeout, source_address=source, **proxy)
         else:
-            return socket.create_connection(addr, source_address=source, timeout=self._keepalive)
+            return socket.create_connection(addr, timeout=self._connect_timeout, source_address=source)
 
 
 # Compatibility class for easy porting from mosquitto.py.


### PR DESCRIPTION
The correct usage for `socket.create_connection` is below:

>socket.create_connection(address[, timeout[, source_address]])
>Connect to a TCP service listening on the Internet address (a 2-tuple (host, port)), and return the socket object. This is a higher-level function than socket.connect(): if host is a non-numeric hostname, it will try to resolve it for both AF_INET and AF_INET6, and then try to connect to all possible addresses in turn until a connection succeeds. This makes it easy to write clients that are compatible to both IPv4 and IPv6.
>Passing the optional timeout parameter will set the timeout on the socket instance before attempting to connect. If no timeout is supplied, the global default timeout setting returned by getdefaulttimeout() is used.
>If supplied, source_address must be a 2-tuple (host, port) for the socket to bind to as its source address before connecting. If host or port are ‘’ or 0 respectively the OS default behavior will be used.
>Changed in version 3.2: source_address was added.

Also the semantics of `connect timeout` and `keepalive timeout` are totally different.