### PR TITLE
Add BlockingIOError definition to allow Paho 1.6.0 to load with Python 2.7

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -81,6 +81,12 @@ if platform.system() == 'Windows':
 else:
     EAGAIN = errno.EAGAIN
 
+# Python 2.7 does not have BlockingIOError.  Fall back to IOError
+try:
+    BlockingIOError
+except NameError:
+    BlockingIOError  = IOError
+
 MQTTv31 = 3
 MQTTv311 = 4
 MQTTv5 = 5


### PR DESCRIPTION
Signed-off-by: Bert Kleewein <bertk@microsoft.com>