### PR TITLE
Add v1.6.0 connection timeout change to change log

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -8,6 +8,8 @@ v1.6.0 - 2021-10-20
 ===================
 
 - Changed default TLS version to 1.2 instead of 1.0.
+- MQTT connection attempts now use a timeout of 5 seconds rather than the
+  configured keepalive interval
 - Fix incoming MQTT v5 messages with overall property length > 127 bytes being
   incorrectly decoded. Closes #541.
 - MQTTMessageInfo.wait_for_publish() and MQTTMessageInfo.is_published() will


### PR DESCRIPTION
I was digging into timeout management to try to figure out a problem we've been seeing, and noticed that this had changed, but wasn't in the change log.