### PR TITLE
Set client_id as thread name

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1808,7 +1808,7 @@ class Client(object):
 
         self._sockpairR, self._sockpairW = _socketpair_compat()
         self._thread_terminate = False
-        self._thread = threading.Thread(target=self._thread_main)
+        self._thread = threading.Thread(target=self._thread_main, name=f"paho-mqtt-client-{self._client_id.decode()}")
         self._thread.daemon = True
         self._thread.start()
 


### PR DESCRIPTION
I had a couple of problems in my code where I pulled up a couple of connections/clients and randomly it happened that in the loop an exception occurred. When it happens the exception always starts like this before the stacktrace:

```
Exception in thread Tread-$some_number:
```

... which gives not too much info where the exception happened, as the stack trace ends always at `loop_forever` and the interesting part would most of the time be who actually started the thread that caused the exception.

The change gives control over how the thread that is created by `loop_start` is named. To not change any API at all I opted for the decoded client id. If not explicitly set, there will be the usual "broker-generated string" as name, but for me that does not give any less information than the mentioned above `Thread-$some_number`. But if you explicitly set the `client_id` (which needs to be unique, so no name clashes possible as far as I can see) the thread will reflect that change, so in the exception it would print:

```
Exception in thread manually_set_client_id:
```