### PR TITLE
Use time_func for timeout in wait_for_publish

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -361,10 +361,10 @@ class MQTTMessageInfo(object):
         elif self.rc > 0:
             raise RuntimeError('Message publish failed: %s' % (error_string(self.rc)))
 
-        timeout_time = None if timeout is None else time.time() + timeout
+        timeout_time = None if timeout is None else time_func() + timeout
         timeout_tenth = None if timeout is None else timeout / 10.
         def timed_out():
-            return False if timeout is None else time.time() > timeout_time
+            return False if timeout is None else time_func() > timeout_time
 
         with self._condition:
             while not self._published and not timed_out():


### PR DESCRIPTION
Hello,

MQTTMessageInfo.wait_for_publish uses time.time, which returns non-monotonic clock time. It should probably be replaced with time_func defined in the same file, which uses time.monotonic when available.

Signed-off-by: Jurij Šteblaj <jurij@steblaj.si>