### PR TITLE
MANIFEST.in: replace epl-v10 by epl-v20

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include edl-v10 epl-v10
+include edl-v10 epl-v20
 include README.rst
 include CONTRIBUTING.md
 include setup.py


### PR DESCRIPTION
Replace `epl-v10` by `epl-v20` due to https://github.com/eclipse/paho.mqtt.python/commit/fabe7500fb6fde31fd98c619e0117d1c651fd18d

Fix #633

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>