### PR TITLE
Add ALPN support

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -732,7 +732,7 @@ class Client(object):
         if hasattr(context, 'check_hostname'):
             self._tls_insecure = not context.check_hostname
 
-    def tls_set(self, ca_certs=None, certfile=None, keyfile=None, cert_reqs=None, tls_version=None, ciphers=None, keyfile_password=None):
+    def tls_set(self, ca_certs=None, certfile=None, keyfile=None, cert_reqs=None, tls_version=None, ciphers=None, keyfile_password=None, alpn_protocols=None):
         """Configure network encryption and authentication options. Enables SSL/TLS support.
 
         ca_certs : a string path to the Certificate Authority certificate files
@@ -807,6 +807,11 @@ class Client(object):
 
         if ciphers is not None:
             context.set_ciphers(ciphers)
+
+        if alpn_protocols is not None:
+            if not getattr(ssl, "HAS_ALPN", None):
+                raise ValueError("SSL library has no support for ALPN")
+            context.set_alpn_protocols(alpn_protocols)
 
         self.tls_set_context(context)
 

--- a/test/lib/08-ssl-connect-alpn.py
+++ b/test/lib/08-ssl-connect-alpn.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# Test whether a client produces a correct connect and subsequent disconnect when using SSL.
+# Client must provide a certificate.
+
+# The client should connect to port 1888 with keepalive=60, clean session set,
+# and client id 08-ssl-connect-alpn
+# It should use the CA certificate ssl/all-ca.crt for verifying the server.
+# The test will send a CONNACK message to the client with rc=0. Upon receiving
+# the CONNACK and verifying that rc=0, the client should send a DISCONNECT
+# message. If rc!=0, the client should exit with an error.
+#
+# Additionally, the secure socket must have been negotiated with the "paho-test-protocol"
+
+import context
+import paho_test
+from paho_test import ssl
+
+context.check_ssl()
+
+rc = 1
+keepalive = 60
+connect_packet = paho_test.gen_connect("08-ssl-connect-alpn", keepalive=keepalive)
+connack_packet = paho_test.gen_connack(rc=0)
+disconnect_packet = paho_test.gen_disconnect()
+
+ssock = paho_test.create_server_socket_ssl(cert_reqs=ssl.CERT_REQUIRED, alpn_protocols=["paho-test-protocol"])
+
+client = context.start_client()
+
+try:
+    (conn, address) = ssock.accept()
+    conn.settimeout(10)
+
+    paho_test.expect_packet(conn, "connect", connect_packet)
+    conn.send(connack_packet)
+
+    paho_test.expect_packet(conn, "disconnect", disconnect_packet)
+    rc = 0
+
+    if getattr(ssl, "HAS_ALPN"):
+        negotiated_protocol = conn.selected_alpn_protocol()
+        if negotiated_protocol != "paho-test-protocol":
+            raise Exception(
+                "Unexpected protocol '{}'".format(negotiated_protocol)
+            )
+
+    conn.close()
+finally:
+    client.terminate()
+    client.wait()
+    ssock.close()
+
+exit(rc)

--- a/test/lib/Makefile
+++ b/test/lib/Makefile
@@ -34,4 +34,5 @@ test :
 	$(PYTHON) ./08-ssl-bad-cacert.py python/08-ssl-bad-cacert.test
 	$(PYTHON) ./08-ssl-connect-cert-auth-pw.py python/08-ssl-connect-cert-auth-pw.test
 	$(PYTHON) ./08-ssl-connect-cert-auth.py python/08-ssl-connect-cert-auth.test
+	$(PYTHON) ./08-ssl-connect-alpn.py python/08-ssl-connect-alpn.test
 	$(PYTHON) ./08-ssl-connect-no-auth.py python/08-ssl-connect-no-auth.test

--- a/test/lib/python/08-ssl-connect-alpn.test
+++ b/test/lib/python/08-ssl-connect-alpn.test
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import sys
+
+import paho.mqtt.client as mqtt
+
+if sys.version_info < (2, 7, 9):
+    print("WARNING: SSL/TLS not supported on Python 2.6")
+    exit(0)
+
+import ssl
+
+if not getattr(ssl, "HAS_ALPN"):
+    print("ALPN not supported in this version of Python")
+    exit(0)
+
+
+def on_connect(mqttc, obj, flags, rc):
+    if rc != 0:
+        exit(rc)
+    else:
+        mqttc.disconnect()
+
+
+def on_disconnect(mqttc, obj, rc):
+    obj = rc
+
+
+run = -1
+mqttc = mqtt.Client("08-ssl-connect-alpn", run)
+mqttc.tls_set("../ssl/all-ca.crt", "../ssl/client.crt", "../ssl/client.key", alpn_protocols=["paho-test-protocol"])
+mqttc.on_connect = on_connect
+mqttc.on_disconnect = on_disconnect
+
+mqttc.connect("localhost", 1888)
+while run == -1:
+    mqttc.loop()
+
+exit(run)


### PR DESCRIPTION
Add ALPN support to `tls_set`. To add the tests I had to change the way the secure sockets are created as well. Using `ssl.wrap_socket` has been deprecated for about 8 years now anyhow