### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
     author='Roger Light',
     author_email='roger@atchoo.org',
     url='http://eclipse.org/paho',
+    project_urls={
+        'Source': 'https://github.com/eclipse/paho.mqtt.python',
+    },
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)