### PR TITLE
Fix Python >=3.10 PROTOCOL_TLS DeprecationWarning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -286,7 +286,7 @@ tls_set()
 .. code:: python
 
     tls_set(ca_certs=None, certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED,
-        tls_version=ssl.PROTOCOL_TLS, ciphers=None)
+        tls_version=ssl.PROTOCOL_TLS_CLIENT, ciphers=None)
 
 Configure network encryption and authentication options. Enables SSL/TLS support.
 

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -787,7 +787,10 @@ class Client(object):
         if tls_version is None:
             tls_version = ssl.PROTOCOL_TLSv1_2
             # If the python version supports it, use highest TLS version automatically
-            if hasattr(ssl, "PROTOCOL_TLS"):
+            if hasattr(ssl, "PROTOCOL_TLS_CLIENT"):
+                # This also enables CERT_REQUIRED and check_hostname by default.
+                tls_version = ssl.PROTOCOL_TLS_CLIENT
+            elif hasattr(ssl, "PROTOCOL_TLS"):
                 tls_version = ssl.PROTOCOL_TLS
         context = ssl.SSLContext(tls_version)
 

--- a/test/paho_test.py
+++ b/test/paho_test.py
@@ -39,7 +39,9 @@ def create_server_socket_ssl(*args, **kwargs):
         raise RuntimeError
 
     ssl_version = ssl.PROTOCOL_TLSv1
-    if hasattr(ssl, "PROTOCOL_TLS"):
+    if hasattr(ssl, "PROTOCOL_TLS_SERVER"):
+        ssl_version = ssl.PROTOCOL_TLS_SERVER
+    elif hasattr(ssl, "PROTOCOL_TLS"):
         ssl_version = ssl.PROTOCOL_TLS
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
PROTOCOL_TLS_CLIENT/_SERVER are attempted to be selected before falling back to the legacy PROTOCOL_TLS setting. The side effects of using PROTOCOL_TLS_CLIENT is that CERT_REQUIRED and check_hostname are enabled by default, but these were explicitly used as a default already and remain to be the defaults even if PROTOCOL_TLS_CLIENT is unavailable.

The settings in `examples\client_pub_opts.py` and `examples\client_sub_opts.py` are unaffected.

Bug: https://github.com/eclipse/paho.mqtt.python/issues/653

The warning is now gone:
![image](https://user-images.githubusercontent.com/11609215/173053064-0a81cff4-fabe-4f23-9389-1c8b807828a6.png)
