### PR TITLE
Move SSL cipher string definition before loading the certificate chain

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -791,6 +791,9 @@ class Client(object):
                 tls_version = ssl.PROTOCOL_TLS
         context = ssl.SSLContext(tls_version)
 
+        if ciphers is not None:
+            context.set_ciphers(ciphers)
+
         # Configure context
         if certfile is not None:
             context.load_cert_chain(certfile, keyfile, keyfile_password)
@@ -804,9 +807,6 @@ class Client(object):
             context.load_verify_locations(ca_certs)
         else:
             context.load_default_certs()
-
-        if ciphers is not None:
-            context.set_ciphers(ciphers)
 
         self.tls_set_context(context)
 


### PR DESCRIPTION
After upgrading to the recent release of Python 3.10 connection to brokers with previous generation self-signed SSL keys no longer work, when connecting, the SSL library throws an error:

`ssl.SSLError: [SSL: CA_MD_TOO_WEAK] ca md too weak`

Changing the broker keys in some use cases may not be possible. The most used workaround I found online was to configure the openssl library in the OS/Docker image level to drop the security level globally and allow weak keys to be used, with solutions such as `RUN sed -i 's/DEFAULT@SECLEVEL=2/DEFAULT@SECLEVEL=1/' /etc/ssl/openssl.cnf`. I find this inappropriate for the sake of a single connection in the system.

The obvious solution is that when configuring SSL for the paho-mqtt client connection, the client.tls_set() method allows cipher strings to be defined for the context. Using the cipher string `DEFAULT@SECLEVEL=1` should have the same effect as when being configured globally as above, however, I found that the exception was still raised.

After some investigation I found that in the client.tls_set() method the cipher string is added to the SSL context as a very last step, after the key chain is loaded into the context. When the keys are being loaded, the SSL library throws the exception and the program flow never arrives to the cipher configuration which would allow those weak keys to be used.

This PR moves the cipher string configuration to the beginning of the context configuration process, so all subsequent context configuration will respect any cipher strings specification.

Signed-off-by: Mate Szabo <matesh@protonmail.com>