### PR TITLE
Handle edge case where socket is None

### DIFF
--- a/src/paho/mqtt/__init__.py
+++ b/src/paho/mqtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.2"
+__version__ = "1.6.1"
 
 
 class MQTTException(Exception):

--- a/src/paho/mqtt/__init__.py
+++ b/src/paho/mqtt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 
 
 class MQTTException(Exception):

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -643,6 +643,10 @@ class Client(object):
         except ssl.SSLWantWriteError:
             self._call_socket_register_write()
             raise BlockingIOError
+        except AttributeError as err:
+            self._easy_log(
+                MQTT_LOG_DEBUG, "socket was None: %s", err)
+            raise ConnectionError
 
     def _sock_send(self, buf):
         try:


### PR DESCRIPTION
* The following exception happens randomly on startup:

```
Exception has occurred: AttributeError
'NoneType' object has no attribute 'recv'
  File "paho/mqtt/client.py", line 640, in _sock_recv
```

* The root cause is unknown, but this allows the library to reconnect gracefully.

Fixes https://github.com/eclipse/paho.mqtt.python/issues/505