### PR TITLE
Adding User Data Getter

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1649,6 +1649,10 @@ class Client(object):
     def user_data_set(self, userdata):
         """Set the user data variable passed to callbacks. May be any data type."""
         self._userdata = userdata
+        
+    def user_data_get(self):
+        """Get the user data variable passed to callbacks. May be any data type."""
+        return self._userdata
 
     def will_set(self, topic, payload=None, qos=0, retain=False, properties=None):
         """Set a Will to be sent by the broker in case the client disconnects unexpectedly.


### PR DESCRIPTION
Adding a getter method for `userdata` for the case of accessing the data outside of a callback. I found this useful when writing unit tests for publish/subscribe events.

Please let me know if there's a reason a getter method was not included in the original codebase. Thanks for supporting this project!

Signed-off-by: arichadda <ari.chadda@gmail.com>