### PR TITLE
Added TimeoutError catching for TCP connection

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2415,6 +2415,10 @@ class Client(object):
                 self._easy_log(
                     MQTT_LOG_ERR, 'failed to receive on socket: %s', err)
                 return MQTT_ERR_CONN_LOST
+            except TimeoutError as err:
+                self._easy_log(
+                    MQTT_LOG_ERR, 'timeout on socket: %s', err)
+                return MQTT_ERR_CONN_LOST
             else:
                 if len(command) == 0:
                     return MQTT_ERR_CONN_LOST

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -626,6 +626,7 @@ class Client(object):
         self._on_socket_close = None
         self._on_socket_register_write = None
         self._on_socket_unregister_write = None
+        self._on_pre_connect = None
         self._websocket_path = "/mqtt"
         self._websocket_extra_headers = None
         # for clean_start == MQTT_CLEAN_START_FIRST_ONLY


### PR DESCRIPTION
When you turn off your internet connection and still publish messages after a timeout raises `TimeoutError: [Errno 60] Operation timed out`

Fixes in this PR catch this error and the client correctly disconnects and closes the socket.

Due to issues #709 and #694 

Signed-off-by: Vitalii Bidochka <vitalikbidochka@gmail.com>