### PR TITLE
Fix Python 2.7 compatibility more

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -87,6 +87,13 @@ try:
 except NameError:
     BlockingIOError  = IOError
 
+# Python 2.7 does not have ConnectionError. Fall back to socket.error
+# (ref. commit 4910b785a49b9)
+try:
+    ConnectionError
+except NameError:
+    ConnectionError = socket.error
+
 MQTTv31 = 3
 MQTTv311 = 4
 MQTTv5 = 5


### PR DESCRIPTION
Nb: I haven't tested this patch.

* Regressed in 4910b785a49b9
* See https://github.com/eclipse/paho.mqtt.python/issues/713
* Follows up on https://github.com/eclipse/paho.mqtt.python/pull/611