### PR TITLE
Restructure & pylint advisories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 *.egg-info/
 .installed.cfg
 *.egg
+/examples/temp*
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ Client()
 
 .. code:: python
 
-    Client(client_id="", clean_session=True, userdata=None, protocol=MQTTv311, transport="tcp")
+    Client(client_id="", clean_session=True, userdata=None, protocol=MQTTV311, transport="tcp")
 
 The ``Client()`` constructor takes the following arguments:
 
@@ -191,7 +191,7 @@ userdata
 
 protocol
     the version of the MQTT protocol to use for this client. Can be either
-    ``MQTTv31``, ``MQTTv311`` or ``MQTTv5``
+    ``MQTTV31``, ``MQTTV311`` or ``MQTTV5``
 
 transport
     set to "websockets" to send MQTT over WebSockets. Leave at the default of
@@ -1193,7 +1193,7 @@ Publish a single message to a broker, then disconnect cleanly.
 
     single(topic, payload=None, qos=0, retain=False, hostname="localhost",
         port=1883, client_id="", keepalive=60, will=None, auth=None, tls=None,
-        protocol=mqtt.MQTTv311, transport="tcp")
+        protocol=mqtt.MQTTV311, transport="tcp")
 
 
 Publish Single Function arguments
@@ -1256,8 +1256,8 @@ tls
     Defaults to None, which indicates that TLS should not be used.
 
 protocol
-    choose the version of the MQTT protocol to use. Use either ``MQTTv31``,
-    ``MQTTv311``, or ``MQTTv5`.
+    choose the version of the MQTT protocol to use. Use either ``MQTTV31``,
+    ``MQTTV311``, or ``MQTTV5`.
 
 transport
     set to "websockets" to send MQTT over WebSockets. Leave at the default of
@@ -1283,7 +1283,7 @@ set any properties on connection or when sending messages.
 .. code:: python
 
     multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
-        will=None, auth=None, tls=None, protocol=mqtt.MQTTv311, transport="tcp")
+        will=None, auth=None, tls=None, protocol=mqtt.MQTTV311, transport="tcp")
 
 Publish Multiple Function arguments
 '''''''''''''''''''''''''''''''''''
@@ -1338,7 +1338,7 @@ blocking function.
 
     simple(topics, qos=0, msg_count=1, retained=False, hostname="localhost",
         port=1883, client_id="", keepalive=60, will=None, auth=None, tls=None,
-        protocol=mqtt.MQTTv311)
+        protocol=mqtt.MQTTV311)
 
 
 Simple Subscribe Function arguments
@@ -1406,8 +1406,8 @@ tls
     Defaults to None, which indicates that TLS should not be used.
 
 protocol
-    choose the version of the MQTT protocol to use. Use either ``MQTTv31``,
-    ``MQTTv311``, or ``MQTTv5``.
+    choose the version of the MQTT protocol to use. Use either ``MQTTV31``,
+    ``MQTTV311``, or ``MQTTV5``.
 
 
 Simple Example
@@ -1430,7 +1430,7 @@ provided callback.
 
     callback(callback, topics, qos=0, userdata=None, hostname="localhost",
         port=1883, client_id="", keepalive=60, will=None, auth=None, tls=None,
-        protocol=mqtt.MQTTv311)
+        protocol=mqtt.MQTTV311)
 
 Callback Subscribe Function arguments
 '''''''''''''''''''''''''''''''''''''

--- a/examples/client_rpc_math.py
+++ b/examples/client_rpc_math.py
@@ -15,7 +15,7 @@
 #   Frank Pagliughi - initial implementation
 #
 
-# This shows an example of an MQTTv5 Remote Procedure Call (RPC) client.
+# This shows an example of an MQTTV5 Remote Procedure Call (RPC) client.
 
 import json
 import sys
@@ -36,7 +36,7 @@ corr_id = b"1"
 # This is sent in the message callback when we get the respone
 reply = None
 
-# The MQTTv5 callback takes the additional 'props' parameter.
+# The MQTTV5 callback takes the additional 'props' parameter.
 def on_connect(mqttc, userdata, flags, rc, props):
     global client_id, reply_to
 
@@ -65,7 +65,7 @@ if len(sys.argv) < 3:
     print("USAGE: client_rpc_math.py [add|mult] n1 n2 ...")
     sys.exit(1)
 
-mqttc = mqtt.Client(client_id="", protocol=mqtt.MQTTv5)
+mqttc = mqtt.Client(client_id="", protocol=mqtt.MQTTV5)
 mqttc.on_message = on_message
 mqttc.on_connect = on_connect
 

--- a/examples/server_rpc_math.py
+++ b/examples/server_rpc_math.py
@@ -15,7 +15,7 @@
 #   Frank Pagliughi - initial implementation
 #
 
-# This shows an example of an MQTTv5 Remote Procedure Call (RPC) server.
+# This shows an example of an MQTTV5 Remote Procedure Call (RPC) server.
 
 import json
 
@@ -38,7 +38,7 @@ def mult(nums):
         prod *= x
     return prod
 
-# Remember that the MQTTv5 callback takes the additional 'props' parameter.
+# Remember that the MQTTV5 callback takes the additional 'props' parameter.
 def on_connect(mqttc, userdata, flags, rc, props):
     print("Connected: '"+str(flags)+"', '"+str(rc)+"', '"+str(props))
     if not flags["session present"]:
@@ -85,7 +85,7 @@ def on_log(mqttc, obj, level, string):
 # Typically with an RPC service, you want to make sure that you're the only
 # client answering requests for specific topics. Using a known client ID 
 # might help.
-mqttc = mqtt.Client(client_id="paho_rpc_math_srvr", protocol=mqtt.MQTTv5)
+mqttc = mqtt.Client(client_id="paho_rpc_math_srvr", protocol=mqtt.MQTTV5)
 mqttc.on_message = on_message
 mqttc.on_connect = on_connect
 

--- a/src/paho/mqtt/__init__.py
+++ b/src/paho/mqtt/__init__.py
@@ -1,5 +1,1 @@
 __version__ = "1.6.1"
-
-
-class MQTTException(Exception):
-    pass

--- a/src/paho/mqtt/constants.py
+++ b/src/paho/mqtt/constants.py
@@ -1,0 +1,151 @@
+"""
+Copyright (c) 2012-2019 Roger Light and others
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+    http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+Contributors:
+    Roger Light - initial API and implementation
+    Ian Craggs - MQTT V5 support
+"""
+
+import logging
+
+MQTT_CLIENT = 0
+MQTT_BRIDGE = 1
+MQTTV31 = 3
+MQTTV311 = 4
+MQTTV5 = 5
+
+# For MQTT V5, use the clean start flag only on the first successful connect
+MQTT_CLEAN_START_FIRST_ONLY = 3
+
+SOCKPAIR_DATA = b"0"
+
+# Message types
+CONNECT = 0x10
+CONNACK = 0x20
+PUBLISH = 0x30
+PUBACK = 0x40
+PUBREC = 0x50
+PUBREL = 0x60
+PUBCOMP = 0x70
+SUBSCRIBE = 0x80
+SUBACK = 0x90
+UNSUBSCRIBE = 0xA0
+UNSUBACK = 0xB0
+PINGREQ = 0xC0
+PINGRESP = 0xD0
+DISCONNECT = 0xE0
+AUTH = 0xF0
+
+# Log levels
+MQTT_LOG_INFO = 0x01
+MQTT_LOG_NOTICE = 0x02
+MQTT_LOG_WARNING = 0x04
+MQTT_LOG_ERR = 0x08
+MQTT_LOG_DEBUG = 0x10
+LOGGING_LEVEL = {
+    MQTT_LOG_DEBUG: logging.DEBUG,
+    MQTT_LOG_INFO: logging.INFO,
+    MQTT_LOG_NOTICE: logging.INFO,  # This has no direct equivalent level
+    MQTT_LOG_WARNING: logging.WARNING,
+    MQTT_LOG_ERR: logging.ERROR,
+}
+
+# Connection state
+MQTT_CS_NEW = 0
+MQTT_CS_CONNECTED = 1
+MQTT_CS_DISCONNECTING = 2
+MQTT_CS_CONNECT_ASYNC = 3
+
+# Message state
+MQTT_MS_INVALID = 0
+MQTT_MS_PUBLISH = 1
+MQTT_MS_WAIT_FOR_PUBACK = 2
+MQTT_MS_WAIT_FOR_PUBREC = 3
+MQTT_MS_RESEND_PUBREL = 4
+MQTT_MS_WAIT_FOR_PUBREL = 5
+MQTT_MS_RESEND_PUBCOMP = 6
+MQTT_MS_WAIT_FOR_PUBCOMP = 7
+MQTT_MS_SEND_PUBREC = 8
+MQTT_MS_QUEUED = 9
+
+# Error values
+MQTT_ERR_AGAIN = -1
+MQTT_ERR_SUCCESS = 0
+MQTT_ERR_NOMEM = 1
+MQTT_ERR_PROTOCOL = 2
+MQTT_ERR_INVAL = 3
+MQTT_ERR_NO_CONN = 4
+MQTT_ERR_CONN_REFUSED = 5
+MQTT_ERR_NOT_FOUND = 6
+MQTT_ERR_CONN_LOST = 7
+MQTT_ERR_TLS = 8
+MQTT_ERR_PAYLOAD_SIZE = 9
+MQTT_ERR_NOT_SUPPORTED = 10
+MQTT_ERR_AUTH = 11
+MQTT_ERR_ACL_DENIED = 12
+MQTT_ERR_UNKNOWN = 13
+MQTT_ERR_ERRNO = 14
+MQTT_ERR_QUEUE_SIZE = 15
+MQTT_ERR_KEEPALIVE = 16
+
+# CONNACK codes
+CONNACK_ACCEPTED = 0
+CONNACK_REFUSED_PROTOCOL_VERSION = 1
+CONNACK_REFUSED_IDENTIFIER_REJECTED = 2
+CONNACK_REFUSED_SERVER_UNAVAILABLE = 3
+CONNACK_REFUSED_BAD_USERNAME_PASSWORD = 4
+CONNACK_REFUSED_NOT_AUTHORIZED = 5
+
+ERR_STRINGS = {
+    MQTT_ERR_SUCCESS: "No error.",
+    MQTT_ERR_NOMEM: "Out of memory.",
+    MQTT_ERR_PROTOCOL: "A network protocol error occurred when communicating with the broker.",
+    MQTT_ERR_INVAL: "Invalid function arguments provided.",
+    MQTT_ERR_NO_CONN: "The client is not currently connected.",
+    MQTT_ERR_CONN_REFUSED: "The connection was refused.",
+    MQTT_ERR_NOT_FOUND: "Message not found (internal error).",
+    MQTT_ERR_CONN_LOST: "The connection was lost.",
+    MQTT_ERR_TLS: "A TLS error occurred.",
+    MQTT_ERR_PAYLOAD_SIZE: "Payload too large.",
+    MQTT_ERR_NOT_SUPPORTED: "This feature is not supported.",
+    MQTT_ERR_AUTH: "Authorisation failed.",
+    MQTT_ERR_ACL_DENIED: "Access denied by ACL.",
+    MQTT_ERR_UNKNOWN: "Unknown error.",
+    MQTT_ERR_ERRNO: "Error defined by errno.",
+    MQTT_ERR_QUEUE_SIZE: "Message queue full.",
+    MQTT_ERR_KEEPALIVE: "Client or broker did not communicate in the keepalive interval.",
+}
+
+CONNACK_STRINGS = {
+    CONNACK_ACCEPTED: "Connection Accepted.",
+    CONNACK_REFUSED_PROTOCOL_VERSION: "Connection Refused: unacceptable protocol version.",
+    CONNACK_REFUSED_IDENTIFIER_REJECTED: "Connection Refused: identifier rejected.",
+    CONNACK_REFUSED_SERVER_UNAVAILABLE: "Connection Refused: broker unavailable.",
+    CONNACK_REFUSED_BAD_USERNAME_PASSWORD: "Connection Refused: bad user name or password.",
+    CONNACK_REFUSED_NOT_AUTHORIZED: "Connection Refused: not authorised.",
+}
+
+
+def error_string(mqtt_errno):
+    """
+    Return the error string associated with an mqtt error number.
+    """
+
+    return ERR_STRINGS.get(mqtt_errno, "Unknown error.")
+
+
+def connack_string(connack_code):
+    """
+    Return the string associated with a CONNACK result.
+    """
+
+    return CONNACK_STRINGS.get(connack_code, "Connection Refused: unknown reason.")

--- a/src/paho/mqtt/exceptions.py
+++ b/src/paho/mqtt/exceptions.py
@@ -1,0 +1,28 @@
+"""
+Copyright (c) 2012-2019 Roger Light and others
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+    http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+Contributors:
+    Roger Light - initial API and implementation
+    Ian Craggs - MQTT V5 support
+"""
+
+
+class MQTTException(Exception):
+    """
+    MQTT Exception.
+    """
+
+
+class MalformedPacket(MQTTException):
+    """
+    Malformed Packet exception.
+    """

--- a/src/paho/mqtt/helpers.py
+++ b/src/paho/mqtt/helpers.py
@@ -1,0 +1,74 @@
+"""
+Copyright (c) 2012-2019 Roger Light and others
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+    http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+Contributors:
+    Roger Light - initial API and implementation
+    Ian Craggs - MQTT V5 support
+"""
+
+import socket
+import string
+from .matcher import MQTTMatcher
+
+def base62(num, base=string.digits + string.ascii_letters, padding=1):
+    """
+    Convert a number to base-62 representation.
+    """
+
+    assert num >= 0
+    digits = []
+    while num:
+        num, rest = divmod(num, 62)
+        digits.append(base[rest])
+    digits.extend(base[0] for _ in range(len(digits), padding))
+    return "".join(reversed(digits))
+
+
+def topic_matches_sub(sub, topic):
+    """Check whether a topic matches a subscription.
+
+    For example:
+
+    foo/bar would match the subscription foo/# or +/bar
+    non/matching would not match the subscription non/+/+
+    """
+
+    matcher = MQTTMatcher()
+    matcher[sub] = True
+    try:
+        next(matcher.iter_match(topic))
+        return True
+    except StopIteration:
+        return False
+
+
+def _socketpair_compat():
+    """
+    TCP/IP socketpair including Windows support.
+    """
+
+    listensock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_IP)
+    listensock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listensock.bind(("127.0.0.1", 0))
+    listensock.listen(1)
+
+    _, port = listensock.getsockname()
+    sock1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_IP)
+    sock1.setblocking(0)
+    try:
+        sock1.connect(("127.0.0.1", port))
+    except BlockingIOError:
+        pass
+    sock2, _ = listensock.accept()
+    sock2.setblocking(0)
+    listensock.close()
+    return (sock1, sock2)

--- a/src/paho/mqtt/matcher.py
+++ b/src/paho/mqtt/matcher.py
@@ -1,12 +1,31 @@
-class MQTTMatcher(object):
-    """Intended to manage topic filters including wildcards.
+"""
+Copyright (c) 2012-2019 Roger Light and others
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+    http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+Contributors:
+    Roger Light - initial API and implementation
+    Ian Craggs - MQTT V5 support
+"""
+
+class MQTTMatcher():
+    """
+    Intended to manage topic filters including wildcards.
 
     Internally, MQTTMatcher use a prefix tree (trie) to store
     values associated with filters, and has an iter_match()
     method to iterate efficiently over all filters that match
-    some topic name."""
+    some topic name.
+    """
 
-    class Node(object):
+    class Node():
         __slots__ = '_children', '_content'
 
         def __init__(self):
@@ -33,8 +52,8 @@ class MQTTMatcher(object):
             if node._content is None:
                 raise KeyError(key)
             return node._content
-        except KeyError:
-            raise KeyError(key)
+        except KeyError as err:
+            raise KeyError(key) from err
 
     def __delitem__(self, key):
         """Delete the value associated with some topic filter :key"""
@@ -42,12 +61,12 @@ class MQTTMatcher(object):
         try:
             parent, node = None, self._root
             for k in key.split('/'):
-                 parent, node = node, node._children[k]
-                 lst.append((parent, k, node))
+                parent, node = node, node._children[k]
+                lst.append((parent, k, node))
             # TODO
             node._content = None
-        except KeyError:
-            raise KeyError(key)
+        except KeyError as err:
+            raise KeyError(key) from err
         else:  # cleanup
             for parent, k, node in reversed(lst):
                 if node._children or node._content is not None:

--- a/src/paho/mqtt/mqttmessage.py
+++ b/src/paho/mqtt/mqttmessage.py
@@ -1,0 +1,94 @@
+"""
+Copyright (c) 2012-2019 Roger Light and others
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+    http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+Contributors:
+    Roger Light - initial API and implementation
+    Ian Craggs - MQTT V5 support
+"""
+
+
+from .constants import MQTT_MS_INVALID
+from .mqttmessageinfo import MQTTMessageInfo
+
+class MQTTMessage():
+    """
+    This is a class that describes an incoming or outgoing message. It is
+    passed to the on_message callback as the message parameter.
+
+    Members:
+
+    topic : String. topic that the message was published on.
+    payload : Bytes/Byte array. the message payload.
+    qos : Integer. The message Quality of Service 0, 1 or 2.
+    retain : Boolean. If true, the message is a retained message and not fresh.
+    mid : Integer. The message id.
+    properties: Properties class. In MQTT v5.0, the properties associated with the message.
+    """
+
+    __slots__ = (
+        "timestamp",
+        "state",
+        "dup",
+        "mid",
+        "_topic",
+        "payload",
+        "qos",
+        "retain",
+        "info",
+        "properties",
+    )
+
+    def __init__(self, mid=0, topic=b""):
+        """
+        Constructor.
+        """
+        self.timestamp = 0
+        self.state = MQTT_MS_INVALID
+        self.dup = False
+        self.mid = mid
+        self._topic = topic
+        self.payload = b""
+        self.qos = 0
+        self.retain = False
+        self.info = MQTTMessageInfo(mid)
+
+    def __eq__(self, other):
+        """
+        Override the default Equals behavior.
+        """
+
+        if isinstance(other, self.__class__):
+            return self.mid == other.mid
+        return False
+
+    def __ne__(self, other):
+        """
+        Define a non-equality test.
+        """
+
+        return not self.__eq__(other)
+
+    @property
+    def topic(self):
+        """
+        Getter for topic.
+        """
+
+        return self._topic.decode("utf-8")
+
+    @topic.setter
+    def topic(self, value):
+        """
+        Setter for topic.
+        """
+
+        self._topic = value

--- a/src/paho/mqtt/mqttmessageinfo.py
+++ b/src/paho/mqtt/mqttmessageinfo.py
@@ -1,0 +1,141 @@
+"""
+Copyright (c) 2012-2019 Roger Light and others
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+    http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+Contributors:
+    Roger Light - initial API and implementation
+    Ian Craggs - MQTT V5 support
+"""
+
+import time
+import threading
+from .constants import MQTT_ERR_QUEUE_SIZE, MQTT_ERR_AGAIN, error_string
+
+class MQTTMessageInfo():
+    """
+    This is a class returned from Client.publish() and can be used to find
+    out the mid of the message that was published, and to determine whether the
+    message has been published, and/or wait until it is published.
+    """
+
+    __slots__ = "mid", "_published", "_condition", "rc", "_iterpos"
+
+    def __init__(self, mid):
+        """
+        Constructor.
+        """
+        self.mid = mid
+        self._published = False
+        self._condition = threading.Condition()
+        self.rc = 0
+        self._iterpos = 0
+
+    def __str__(self):
+        """
+        Human readable string.
+        """
+
+        return str((self.rc, self.mid))
+
+    def __iter__(self):
+        """
+        Iterator.
+        """
+
+        self._iterpos = 0
+        return self
+
+    def __next__(self):
+        """
+        Get next iteration.
+        """
+
+        return self.next()
+
+    def next(self):
+        """
+        Get next iteration.
+        """
+
+        if self._iterpos == 0:
+            self._iterpos = 1
+            return self.rc
+        if self._iterpos == 1:
+            self._iterpos = 2
+            return self.mid
+        raise StopIteration
+
+    def __getitem__(self, index):
+        """
+        Get item.
+        """
+
+        if index == 0:
+            return self.rc
+        if index == 1:
+            return self.mid
+        raise IndexError("index out of range")
+
+    def _set_as_published(self):
+        """
+        Set published flag.
+        """
+
+        with self._condition:
+            self._published = True
+            self._condition.notify()
+
+    def wait_for_publish(self, timeout=None):
+        """
+        Block until the message associated with this object is published, or
+        until the timeout occurs. If timeout is None, this will never time out.
+        Set timeout to a positive number of seconds, e.g. 1.2, to enable the
+        timeout.
+
+        Raises ValueError if the message was not queued due to the outgoing
+        queue being full.
+
+        Raises RuntimeError if the message was not published for another
+        reason.
+        """
+
+        if self.rc == MQTT_ERR_QUEUE_SIZE:
+            raise ValueError("Message is not queued due to ERR_QUEUE_SIZE")
+        if self.rc == MQTT_ERR_AGAIN:
+            pass
+        elif self.rc > 0:
+            raise RuntimeError(f"Message publish failed: {error_string(self.rc)}")
+
+        timeout_time = None if timeout is None else time.time() + timeout
+        timeout_tenth = None if timeout is None else timeout / 10.0
+
+        def timed_out():
+            return False if timeout is None else time.time() > timeout_time
+
+        with self._condition:
+            while not self._published and not timed_out():
+                self._condition.wait(timeout_tenth)
+
+    def is_published(self):
+        """
+        Returns True if the message associated with this object has been
+        published, else returns False.
+        """
+
+        if self.rc == MQTT_ERR_QUEUE_SIZE:
+            raise ValueError("Message is not queued due to ERR_QUEUE_SIZE")
+        if self.rc == MQTT_ERR_AGAIN:
+            pass
+        elif self.rc > 0:
+            raise RuntimeError(f"Message publish failed: {error_string(self.rc)}")
+
+        with self._condition:
+            return self._published

--- a/src/paho/mqtt/properties.py
+++ b/src/paho/mqtt/properties.py
@@ -19,16 +19,8 @@
 import struct
 import sys
 
+from .exceptions import MQTTException, MalformedPacket
 from .packettypes import PacketTypes
-
-
-class MQTTException(Exception):
-    pass
-
-
-class MalformedPacket(MQTTException):
-    pass
-
 
 def writeInt16(length):
     # serialize a 16 bit integer to network format

--- a/src/paho/mqtt/publish.py
+++ b/src/paho/mqtt/publish.py
@@ -27,8 +27,9 @@ try:
 except ImportError:
     from collections import Iterable
 
-from .. import mqtt
-from . import client as paho
+from .exceptions import MQTTException
+from .constants import MQTTV311, MQTTV5, connack_string
+from .client import Client
 
 
 def _do_publish(client):
@@ -52,7 +53,7 @@ def _on_connect(client, userdata, flags, rc):
         if len(userdata) > 0:
             _do_publish(client)
     else:
-        raise mqtt.MQTTException(paho.connack_string(rc))
+        raise MQTTException(connack_string(rc))
 
 def _on_connect_v5(client, userdata, flags, rc, properties):
     """Internal v5 callback"""
@@ -69,7 +70,7 @@ def _on_publish(client, userdata, mid):
 
 
 def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
-             will=None, auth=None, tls=None, protocol=paho.MQTTV311,
+             will=None, auth=None, tls=None, protocol=MQTTV311,
              transport="tcp", proxy_args=None):
     """Publish multiple messages to a broker, then disconnect cleanly.
 
@@ -137,11 +138,11 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
         raise TypeError('msgs must be an iterable')
 
 
-    client = paho.Client(client_id=client_id, userdata=collections.deque(msgs),
+    client = Client(client_id=client_id, userdata=collections.deque(msgs),
                          protocol=protocol, transport=transport)
 
     client.on_publish = _on_publish
-    if protocol == mqtt.client.MQTTV5:
+    if protocol == MQTTV5:
         client.on_connect = _on_connect_v5
     else:
         client.on_connect = _on_connect
@@ -179,7 +180,7 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
 
 def single(topic, payload=None, qos=0, retain=False, hostname="localhost",
            port=1883, client_id="", keepalive=60, will=None, auth=None,
-           tls=None, protocol=paho.MQTTV311, transport="tcp", proxy_args=None):
+           tls=None, protocol=MQTTV311, transport="tcp", proxy_args=None):
     """Publish a single message to a broker, then disconnect cleanly.
 
     This function creates an MQTT client, connects to a broker and publishes a

--- a/src/paho/mqtt/publish.py
+++ b/src/paho/mqtt/publish.py
@@ -69,7 +69,7 @@ def _on_publish(client, userdata, mid):
 
 
 def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
-             will=None, auth=None, tls=None, protocol=paho.MQTTv311,
+             will=None, auth=None, tls=None, protocol=paho.MQTTV311,
              transport="tcp", proxy_args=None):
     """Publish multiple messages to a broker, then disconnect cleanly.
 
@@ -141,7 +141,7 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
                          protocol=protocol, transport=transport)
 
     client.on_publish = _on_publish
-    if protocol == mqtt.client.MQTTv5:
+    if protocol == mqtt.client.MQTTV5:
         client.on_connect = _on_connect_v5
     else:
         client.on_connect = _on_connect
@@ -179,7 +179,7 @@ def multiple(msgs, hostname="localhost", port=1883, client_id="", keepalive=60,
 
 def single(topic, payload=None, qos=0, retain=False, hostname="localhost",
            port=1883, client_id="", keepalive=60, will=None, auth=None,
-           tls=None, protocol=paho.MQTTv311, transport="tcp", proxy_args=None):
+           tls=None, protocol=paho.MQTTV311, transport="tcp", proxy_args=None):
     """Publish a single message to a broker, then disconnect cleanly.
 
     This function creates an MQTT client, connects to a broker and publishes a

--- a/src/paho/mqtt/subscribe.py
+++ b/src/paho/mqtt/subscribe.py
@@ -20,14 +20,15 @@ you to pass a callback for processing of messages.
 """
 from __future__ import absolute_import
 
-from .. import mqtt
-from . import client as paho
+from .exceptions import MQTTException
+from .constants import MQTTV5, MQTTV311, connack_string
+from .client import Client
 
 
 def _on_connect_v5(client, userdata, flags, rc, properties):
     """Internal callback"""
     if rc != 0:
-        raise mqtt.MQTTException(paho.connack_string(rc))
+        raise MQTTException(connack_string(rc))
 
     if isinstance(userdata['topics'], list):
         for topic in userdata['topics']:
@@ -69,7 +70,7 @@ def _on_message_simple(client, userdata, message):
 
 def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
              port=1883, client_id="", keepalive=60, will=None, auth=None,
-             tls=None, protocol=paho.MQTTV311, transport="tcp",
+             tls=None, protocol=MQTTV311, transport="tcp",
              clean_session=True, proxy_args=None):
     """Subscribe to a list of topics and process them in a callback function.
 
@@ -143,11 +144,11 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
         'qos':qos,
         'userdata':userdata}
 
-    client = paho.Client(client_id=client_id, userdata=callback_userdata,
+    client = Client(client_id=client_id, userdata=callback_userdata,
                          protocol=protocol, transport=transport,
                          clean_session=clean_session)
     client.on_message = _on_message_callback
-    if protocol == mqtt.client.MQTTV5:
+    if protocol == MQTTV5:
         client.on_connect = _on_connect_v5
     else:
         client.on_connect = _on_connect
@@ -185,7 +186,7 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
 
 def simple(topics, qos=0, msg_count=1, retained=True, hostname="localhost",
            port=1883, client_id="", keepalive=60, will=None, auth=None,
-           tls=None, protocol=paho.MQTTV311, transport="tcp",
+           tls=None, protocol=MQTTV311, transport="tcp",
            clean_session=True, proxy_args=None):
     """Subscribe to a list of topics and return msg_count messages.
 

--- a/src/paho/mqtt/subscribe.py
+++ b/src/paho/mqtt/subscribe.py
@@ -69,7 +69,7 @@ def _on_message_simple(client, userdata, message):
 
 def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
              port=1883, client_id="", keepalive=60, will=None, auth=None,
-             tls=None, protocol=paho.MQTTv311, transport="tcp",
+             tls=None, protocol=paho.MQTTV311, transport="tcp",
              clean_session=True, proxy_args=None):
     """Subscribe to a list of topics and process them in a callback function.
 
@@ -147,7 +147,7 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
                          protocol=protocol, transport=transport,
                          clean_session=clean_session)
     client.on_message = _on_message_callback
-    if protocol == mqtt.client.MQTTv5:
+    if protocol == mqtt.client.MQTTV5:
         client.on_connect = _on_connect_v5
     else:
         client.on_connect = _on_connect
@@ -185,7 +185,7 @@ def callback(callback, topics, qos=0, userdata=None, hostname="localhost",
 
 def simple(topics, qos=0, msg_count=1, retained=True, hostname="localhost",
            port=1883, client_id="", keepalive=60, will=None, auth=None,
-           tls=None, protocol=paho.MQTTv311, transport="tcp",
+           tls=None, protocol=paho.MQTTV311, transport="tcp",
            clean_session=True, proxy_args=None):
     """Subscribe to a list of topics and return msg_count messages.
 

--- a/src/paho/mqtt/subscribeoptions.py
+++ b/src/paho/mqtt/subscribeoptions.py
@@ -17,10 +17,7 @@
 """
 
 import sys
-
-
-class MQTTException(Exception):
-    pass
+from .exceptions import MQTTException
 
 
 class SubscribeOptions(object):

--- a/src/paho/mqtt/websocket.py
+++ b/src/paho/mqtt/websocket.py
@@ -1,0 +1,387 @@
+"""
+Copyright (c) 2012-2019 Roger Light and others
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+    http://www.eclipse.org/legal/epl-v10.html
+and the Eclipse Distribution License is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+Contributors:
+    Roger Light - initial API and implementation
+    Ian Craggs - MQTT V5 support
+"""
+
+import os
+import struct
+import base64
+import hashlib
+import uuid
+
+
+class WebsocketConnectionError(ValueError):
+    """
+    WebsocketConnectionError class.
+    """
+
+
+class WebsocketWrapper:
+    """
+    WebsocketWrapper class.
+    """
+
+    OPCODE_CONTINUATION = 0x0
+    OPCODE_TEXT = 0x1
+    OPCODE_BINARY = 0x2
+    OPCODE_CONNCLOSE = 0x8
+    OPCODE_PING = 0x9
+    OPCODE_PONG = 0xA
+
+    def __init__(self, socket, host, port, is_ssl, path, extra_headers):
+        """
+        Constructor.
+        """
+
+        self.connected = False
+
+        self._ssl = is_ssl
+        self._host = host
+        self._port = port
+        self._socket = socket
+        self._path = path
+
+        self._sendbuffer = bytearray()
+        self._readbuffer = bytearray()
+
+        self._requested_size = 0
+        self._payload_head = 0
+        self._readbuffer_head = 0
+
+        self._do_handshake(extra_headers)
+
+    def __del__(self):
+        """
+        Nullify send and read buffers.
+        """
+
+        self._sendbuffer = None
+        self._readbuffer = None
+
+    def _do_handshake(self, extra_headers):
+        """
+        Do handshake.
+        """
+
+        sec_websocket_key = uuid.uuid4().bytes
+        sec_websocket_key = base64.b64encode(sec_websocket_key)
+
+        websocket_headers = {
+            "Host": "{self._host:s}:{self._port:d}".format(self=self),
+            "Upgrade": "websocket",
+            "Connection": "Upgrade",
+            "Origin": "https://{self._host:s}:{self._port:d}".format(self=self),
+            "Sec-WebSocket-Key": sec_websocket_key.decode("utf8"),
+            "Sec-Websocket-Version": "13",
+            "Sec-Websocket-Protocol": "mqtt",
+        }
+
+        # This is checked in ws_set_options so it will either be None, a
+        # dictionary, or a callable
+        if isinstance(extra_headers, dict):
+            websocket_headers.update(extra_headers)
+        elif callable(extra_headers):
+            websocket_headers = extra_headers(websocket_headers)
+
+        parms = "\r\n".join(f"{i}: {j}" for i, j in websocket_headers.items())
+        header = (f"GET {self._path} HTTP/1.1\r\n{parms}\r\n\r\n").encode("utf8")
+        self._socket.send(header)
+
+        has_secret = False
+        has_upgrade = False
+
+        while True:
+            # read HTTP response header as lines
+            byte = self._socket.recv(1)
+
+            self._readbuffer.extend(byte)
+
+            # line end
+            if byte == b"\n":
+                if len(self._readbuffer) > 2:
+                    # check upgrade
+                    if b"connection" in str(self._readbuffer).lower().encode("utf-8"):
+                        if b"upgrade" not in str(self._readbuffer).lower().encode(
+                            "utf-8"
+                        ):
+                            raise WebsocketConnectionError(
+                                "WebSocket handshake error, connection not upgraded"
+                            )
+                        has_upgrade = True
+
+                    # check key hash
+                    if b"sec-websocket-accept" in str(self._readbuffer).lower().encode(
+                        "utf-8"
+                    ):
+                        GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+                        server_hash = self._readbuffer.decode("utf-8").split(": ", 1)[1]
+                        server_hash = server_hash.strip().encode("utf-8")
+
+                        client_hash = sec_websocket_key.decode("utf-8") + GUID
+                        client_hash = hashlib.sha1(client_hash.encode("utf-8"))
+                        client_hash = base64.b64encode(client_hash.digest())
+
+                        if server_hash != client_hash:
+                            raise WebsocketConnectionError(
+                                "WebSocket handshake error, invalid secret key"
+                            )
+                        has_secret = True
+                else:
+                    # ending linebreak
+                    break
+
+                # reset linebuffer
+                self._readbuffer = bytearray()
+
+            # connection reset
+            elif not byte:
+                raise WebsocketConnectionError("WebSocket handshake error")
+
+        if not has_upgrade or not has_secret:
+            raise WebsocketConnectionError("WebSocket handshake error")
+
+        self._readbuffer = bytearray()
+        self.connected = True
+
+    def _create_frame(self, opcode, data, do_masking=1):
+        """
+        Create frame.
+        """
+
+        header = bytearray()
+        length = len(data)
+
+        mask_key = bytearray(os.urandom(4))
+        mask_flag = do_masking
+
+        # 1 << 7 is the final flag, we don't send continuated data
+        header.append(1 << 7 | opcode)
+
+        if length < 126:
+            header.append(mask_flag << 7 | length)
+
+        elif length < 65536:
+            header.append(mask_flag << 7 | 126)
+            header += struct.pack("!H", length)
+
+        elif length < 0x8000000000000001:
+            header.append(mask_flag << 7 | 127)
+            header += struct.pack("!Q", length)
+
+        else:
+            raise ValueError("Maximum payload size is 2^63")
+
+        if mask_flag == 1:
+            for index in range(length):
+                data[index] ^= mask_key[index % 4]
+            data = mask_key + data
+
+        return header + data
+
+    def _buffered_read(self, length):
+        """
+        Buffered read.
+        """
+
+        # try to recv and store needed bytes
+        wanted_bytes = length - (len(self._readbuffer) - self._readbuffer_head)
+        if wanted_bytes > 0:
+            data = self._socket.recv(wanted_bytes)
+
+            if not data:
+                raise ConnectionAbortedError
+            self._readbuffer.extend(data)
+
+            if len(data) < wanted_bytes:
+                raise BlockingIOError
+
+        self._readbuffer_head += length
+        return self._readbuffer[self._readbuffer_head - length : self._readbuffer_head]
+
+    def _recv_impl(self, length):
+        """
+        Receive impl.
+
+        Try to decode websocket payload part from data.
+        """
+
+        try:
+            self._readbuffer_head = 0
+
+            result = None
+
+            chunk_startindex = self._payload_head
+            chunk_endindex = self._payload_head + length
+
+            header1 = self._buffered_read(1)
+            header2 = self._buffered_read(1)
+
+            opcode = header1[0] & 0x0F
+            maskbit = header2[0] & 0x80 == 0x80
+            lengthbits = header2[0] & 0x7F
+            payload_length = lengthbits
+            mask_key = None
+
+            # read length
+            if lengthbits == 0x7E:
+                value = self._buffered_read(2)
+                (payload_length,) = struct.unpack("!H", value)
+
+            elif lengthbits == 0x7F:
+                value = self._buffered_read(8)
+                (payload_length,) = struct.unpack("!Q", value)
+
+            # read mask
+            if maskbit:
+                mask_key = self._buffered_read(4)
+
+            # if frame payload is shorter than the requested data, read only the possible part
+            readindex = chunk_endindex
+            if payload_length < readindex:
+                readindex = payload_length
+
+            if readindex > 0:
+                # get payload chunk
+                payload = self._buffered_read(readindex)
+
+                # unmask only the needed part
+                if maskbit:
+                    for index in range(chunk_startindex, readindex):
+                        payload[index] ^= mask_key[index % 4]
+
+                result = payload[chunk_startindex:readindex]
+                self._payload_head = readindex
+            else:
+                payload = bytearray()
+
+            # check if full frame arrived and reset readbuffer and payloadhead if needed
+            if readindex == payload_length:
+                self._readbuffer = bytearray()
+                self._payload_head = 0
+
+                # respond to non-binary opcodes, their arrival is not
+                # guaranteed beacause of non-blocking sockets
+                if opcode == WebsocketWrapper.OPCODE_CONNCLOSE:
+                    frame = self._create_frame(
+                        WebsocketWrapper.OPCODE_CONNCLOSE, payload, 0
+                    )
+                    self._socket.send(frame)
+
+                if opcode == WebsocketWrapper.OPCODE_PING:
+                    frame = self._create_frame(WebsocketWrapper.OPCODE_PONG, payload, 0)
+                    self._socket.send(frame)
+
+            # This isn't *proper* handling of continuation frames, but given
+            # that we only support binary frames, it is *probably* good enough.
+            if (
+                opcode
+                in (
+                    WebsocketWrapper.OPCODE_BINARY,
+                    WebsocketWrapper.OPCODE_CONTINUATION,
+                )
+                and payload_length > 0
+            ):
+                return result
+            raise BlockingIOError
+
+        except ConnectionError:
+            self.connected = False
+            return b""
+
+    def _send_impl(self, data):
+        """
+        Send
+        """
+
+        # if previous frame was sent successfully
+        if len(self._sendbuffer) == 0:
+            # create websocket frame
+            frame = self._create_frame(WebsocketWrapper.OPCODE_BINARY, bytearray(data))
+            self._sendbuffer.extend(frame)
+            self._requested_size = len(data)
+
+        # try to write out as much as possible
+        length = self._socket.send(self._sendbuffer)
+
+        self._sendbuffer = self._sendbuffer[length:]
+
+        if len(self._sendbuffer) == 0:
+            # buffer sent out completely, return with payload's size
+            return self._requested_size
+        # couldn't send whole data, request the same data again with 0 as sent length
+        return 0
+
+    def recv(self, length):
+        """
+        Return specific number of bytes.
+        """
+
+        return self._recv_impl(length)
+
+    def read(self, length):
+        """
+        Read data.
+        """
+
+        return self._recv_impl(length)
+
+    def send(self, data):
+        """
+        Send data.
+        """
+
+        return self._send_impl(data)
+
+    def write(self, data):
+        """
+        Write data.
+        """
+
+        return self._send_impl(data)
+
+    def close(self):
+        """
+        Close socket.
+        """
+
+        self._socket.close()
+
+    def fileno(self):
+        """
+        Get fileno.
+        """
+
+        return self._socket.fileno()
+
+    def pending(self):
+        """
+        Get pending flag.
+
+        Fix for bug #131: a SSL socket may still have data available
+        for reading without select() being aware of it.
+        """
+
+        if self._ssl:
+            return self._socket.pending()
+        # normal socket rely only on select()
+        return 0
+
+    def setblocking(self, flag):
+        """
+        Set blocking flag.
+        """
+
+        self._socket.setblocking(flag)

--- a/test/lib/python/01-zero-length-clientid.test
+++ b/test/lib/python/01-zero-length-clientid.test
@@ -22,7 +22,7 @@ def on_disconnect(mqttc, obj, rc):
 
 
 run = -1
-mqttc = mqtt.Client("", run, protocol=mqtt.MQTTv311)
+mqttc = mqtt.Client("", run, protocol=mqtt.MQTTV311)
 mqttc.on_connect = on_connect
 mqttc.on_disconnect = on_disconnect
 

--- a/test/lib/python/03-publish-helper-qos0-v5.test
+++ b/test/lib/python/03-publish-helper-qos0-v5.test
@@ -11,5 +11,5 @@ paho.mqtt.publish.single(
     hostname="localhost",
     port=1888,
     client_id="publish-helper-qos0-test",
-    protocol=paho.mqtt.client.MQTTv5
+    protocol=paho.mqtt.client.MQTTV5
 )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,8 +24,8 @@ from testsupport.broker import fake_broker
 
 
 @pytest.mark.parametrize("proto_ver", [
-    (client.MQTTv31),
-    (client.MQTTv311),
+    (client.MQTTV31),
+    (client.MQTTV311),
 ])
 class Test_connect(object):
     """

--- a/tests/test_mqttv5.py
+++ b/tests/test_mqttv5.py
@@ -119,7 +119,7 @@ class Callbacks:
 def cleanRetained(port):
     callback = Callbacks()
     curclient = paho.mqtt.client.Client("clean retained".encode("utf-8"),
-                                        protocol=paho.mqtt.client.MQTTv5)
+                                        protocol=paho.mqtt.client.MQTTV5)
     curclient.loop_start()
     callback.register(curclient)
     curclient.connect(host="localhost", port=port)
@@ -142,7 +142,7 @@ def cleanup(port):
 
     for clientid in clientids:
         curclient = paho.mqtt.client.Client(clientid.encode(
-            "utf-8"), protocol=paho.mqtt.client.MQTTv5)
+            "utf-8"), protocol=paho.mqtt.client.MQTTV5)
         curclient.loop_start()
         curclient.connect(host="localhost", port=port, clean_start=True)
         time.sleep(.1)
@@ -188,11 +188,11 @@ class Test(unittest.TestCase):
         #aclient = mqtt_client.Client(b"\xEF\xBB\xBF" + "myclientid".encode("utf-8"))
         #aclient = mqtt_client.Client("myclientid".encode("utf-8"))
         aclient = paho.mqtt.client.Client("aclient".encode(
-            "utf-8"), protocol=paho.mqtt.client.MQTTv5)
+            "utf-8"), protocol=paho.mqtt.client.MQTTV5)
         callback.register(aclient)
 
         bclient = paho.mqtt.client.Client("bclient".encode(
-            "utf-8"), protocol=paho.mqtt.client.MQTTv5)
+            "utf-8"), protocol=paho.mqtt.client.MQTTV5)
         callback2.register(bclient)
 
     @classmethod
@@ -328,7 +328,7 @@ class Test(unittest.TestCase):
 
         callback0 = Callbacks()
 
-        client0 = paho.mqtt.client.Client(protocol=paho.mqtt.client.MQTTv5)
+        client0 = paho.mqtt.client.Client(protocol=paho.mqtt.client.MQTTV5)
         callback0.register(client0)
         client0.loop_start()
         # should not be rejected
@@ -340,7 +340,7 @@ class Test(unittest.TestCase):
         client0.disconnect()
         client0.loop_stop()
 
-        client0 = paho.mqtt.client.Client(protocol=paho.mqtt.client.MQTTv5)
+        client0 = paho.mqtt.client.Client(protocol=paho.mqtt.client.MQTTV5)
         callback0.register(client0)
         client0.loop_start()
         client0.connect(host="localhost", port=self._test_broker_port)  # should work
@@ -353,7 +353,7 @@ class Test(unittest.TestCase):
 
         # when we supply a client id, we should not get one assigned
         client0 = paho.mqtt.client.Client(
-            "client0", protocol=paho.mqtt.client.MQTTv5)
+            "client0", protocol=paho.mqtt.client.MQTTV5)
         callback0.register(client0)
         client0.loop_start()
         client0.connect(host="localhost", port=self._test_broker_port)  # should work
@@ -371,7 +371,7 @@ class Test(unittest.TestCase):
         clientid = "offline message queueing".encode("utf-8")
 
         oclient = paho.mqtt.client.Client(
-            clientid, protocol=paho.mqtt.client.MQTTv5)
+            clientid, protocol=paho.mqtt.client.MQTTV5)
         ocallback.register(oclient)
         connect_properties = Properties(PacketTypes.CONNECT)
         connect_properties.SessionExpiryInterval = 99999
@@ -394,7 +394,7 @@ class Test(unittest.TestCase):
         bclient.loop_stop()
 
         oclient = paho.mqtt.client.Client(
-            clientid, protocol=paho.mqtt.client.MQTTv5)
+            clientid, protocol=paho.mqtt.client.MQTTV5)
         ocallback.register(oclient)
         oclient.loop_start()
         oclient.connect(host="localhost", port=self._test_broker_port, clean_start=False)
@@ -416,7 +416,7 @@ class Test(unittest.TestCase):
         clientid = "overlapping subscriptions".encode("utf-8")
 
         oclient = paho.mqtt.client.Client(
-            clientid, protocol=paho.mqtt.client.MQTTv5)
+            clientid, protocol=paho.mqtt.client.MQTTV5)
         ocallback.register(oclient)
 
         oclient.loop_start()
@@ -451,7 +451,7 @@ class Test(unittest.TestCase):
         ocallback = Callbacks()
         clientid = "subscribe failure".encode("utf-8")
         oclient = paho.mqtt.client.Client(
-            clientid, protocol=paho.mqtt.client.MQTTv5)
+            clientid, protocol=paho.mqtt.client.MQTTV5)
         ocallback.register(oclient)
         oclient.loop_start()
         oclient.connect(host="localhost", port=self._test_broker_port)
@@ -498,7 +498,7 @@ class Test(unittest.TestCase):
     def new_client(self, clientid):
         callback = Callbacks()
         client = paho.mqtt.client.Client(clientid.encode(
-            "utf-8"), protocol=paho.mqtt.client.MQTTv5)
+            "utf-8"), protocol=paho.mqtt.client.MQTTV5)
         callback.register(client)
         client.loop_start()
         return client, callback
@@ -1365,4 +1365,4 @@ def setData():
     topics = ("TopicA", "TopicA/B", "Topic/C", "TopicA/C", "/TopicA")
     wildtopics = ("TopicA/+", "+/C", "#", "/#", "/+", "+/+", "TopicA/#")
     nosubscribe_topics = ("test/nosubscribe",)
-    topic_prefix = "paho.mqtt.client.mqttv5/"
+    topic_prefix = "paho.mqtt.client.MQTTV5/"

--- a/tests/test_websocket_integration.py
+++ b/tests/test_websocket_integration.py
@@ -40,8 +40,8 @@ def get_websocket_response(response_headers):
 
 
 @pytest.mark.parametrize("proto_ver,proto_name", [
-    (client.MQTTv31, "MQIsdp"),
-    (client.MQTTv311, "MQTT"),
+    (client.MQTTV31, "MQIsdp"),
+    (client.MQTTV311, "MQTT"),
 ])
 class TestInvalidWebsocketResponse(object):
     def test_unexpected_response(self, proto_ver, proto_name, fake_websocket_broker):
@@ -66,8 +66,8 @@ class TestInvalidWebsocketResponse(object):
 
 
 @pytest.mark.parametrize("proto_ver,proto_name", [
-    (client.MQTTv31, "MQIsdp"),
-    (client.MQTTv311, "MQTT"),
+    (client.MQTTV31, "MQIsdp"),
+    (client.MQTTV311, "MQTT"),
 ])
 class TestBadWebsocketHeaders(object):
     """ Testing for basic functionality in checking for headers """
@@ -127,8 +127,8 @@ class TestBadWebsocketHeaders(object):
 
 
 @pytest.mark.parametrize("proto_ver,proto_name", [
-    (client.MQTTv31, "MQIsdp"),
-    (client.MQTTv311, "MQTT"),
+    (client.MQTTV31, "MQIsdp"),
+    (client.MQTTV311, "MQTT"),
 ])
 class TestValidHeaders(object):
     """ Testing for functionality in request/response headers """


### PR DESCRIPTION
1. Restructure code to make it slightly less monolithic (though client.py module is still over 3,800 lines long) - place each class in a separate module; place exceptions, strings and constants in separate modules.
2. Address some of the easier lint advisories (using pylint v2.17) - client.py lint score increased from 8.42 to 9.42. Note that many pre-existing lint issues remain, including apparently some Error categories.

No (intentional) changes in functionality.