### PR TITLE
License: Fix all links for EPL-2.0

### DIFF
--- a/notice.html
+++ b/notice.html
@@ -22,7 +22,7 @@
 <h3>Applicable Licenses</h3>
 
 <p>Unless otherwise indicated, all Content made available by the Eclipse Foundation is provided to you under the terms and conditions of the Eclipse Public License Version 2.0
-   (&quot;EPL&quot;).  A copy of the EPL is provided with this Content and is also available at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+   (&quot;EPL&quot;).  A copy of the EPL is provided with this Content and is also available at <a href="http://www.eclipse.org/legal/epl-v20.html">http://www.eclipse.org/legal/epl-v20.html</a>.
    For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
 
 <p>Content includes, but is not limited to, source code, object code, documentation and other files maintained in the Eclipse Foundation source code

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -5,7 +5,7 @@
 # and Eclipse Distribution License v1.0 which accompany this distribution.
 #
 # The Eclipse Public License is available at
-#    http://www.eclipse.org/legal/epl-v10.html
+#    http://www.eclipse.org/legal/epl-v20.html
 # and the Eclipse Distribution License is available at
 #   http://www.eclipse.org/org/documents/edl-v10.php.
 #

--- a/src/paho/mqtt/packettypes.py
+++ b/src/paho/mqtt/packettypes.py
@@ -7,7 +7,7 @@
   and Eclipse Distribution License v1.0 which accompany this distribution.
 
   The Eclipse Public License is available at
-     http://www.eclipse.org/legal/epl-v10.html
+     http://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at
     http://www.eclipse.org/org/documents/edl-v10.php.
 

--- a/src/paho/mqtt/properties.py
+++ b/src/paho/mqtt/properties.py
@@ -7,7 +7,7 @@
   and Eclipse Distribution License v1.0 which accompany this distribution.
 
   The Eclipse Public License is available at
-     http://www.eclipse.org/legal/epl-v10.html
+     http://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at
     http://www.eclipse.org/org/documents/edl-v10.php.
 

--- a/src/paho/mqtt/publish.py
+++ b/src/paho/mqtt/publish.py
@@ -5,7 +5,7 @@
 # and Eclipse Distribution License v1.0 which accompany this distribution.
 #
 # The Eclipse Public License is available at
-#    http://www.eclipse.org/legal/epl-v10.html
+#    http://www.eclipse.org/legal/epl-v20.html
 # and the Eclipse Distribution License is available at
 #   http://www.eclipse.org/org/documents/edl-v10.php.
 #

--- a/src/paho/mqtt/reasoncodes.py
+++ b/src/paho/mqtt/reasoncodes.py
@@ -7,7 +7,7 @@
   and Eclipse Distribution License v1.0 which accompany this distribution.
 
   The Eclipse Public License is available at
-     http://www.eclipse.org/legal/epl-v10.html
+     http://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at
     http://www.eclipse.org/org/documents/edl-v10.php.
 

--- a/src/paho/mqtt/subscribe.py
+++ b/src/paho/mqtt/subscribe.py
@@ -5,7 +5,7 @@
 # and Eclipse Distribution License v1.0 which accompany this distribution.
 #
 # The Eclipse Public License is available at
-#    http://www.eclipse.org/legal/epl-v10.html
+#    http://www.eclipse.org/legal/epl-v20.html
 # and the Eclipse Distribution License is available at
 #   http://www.eclipse.org/org/documents/edl-v10.php.
 #

--- a/src/paho/mqtt/subscribeoptions.py
+++ b/src/paho/mqtt/subscribeoptions.py
@@ -7,7 +7,7 @@
   and Eclipse Distribution License v1.0 which accompany this distribution.
 
   The Eclipse Public License is available at
-     http://www.eclipse.org/legal/epl-v10.html
+     http://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at
     http://www.eclipse.org/org/documents/edl-v10.php.
 

--- a/tests/test_mqttv5.py
+++ b/tests/test_mqttv5.py
@@ -7,7 +7,7 @@
   and Eclipse Distribution License v1.0 which accompany this distribution.
 
   The Eclipse Public License is available at
-     http://www.eclipse.org/legal/epl-v10.html
+     http://www.eclipse.org/legal/epl-v20.html
   and the Eclipse Distribution License is available at
     http://www.eclipse.org/org/documents/edl-v10.php.
 


### PR DESCRIPTION
Even though the repository is licensed under `EPL-2.0`,
a lot of links pointed to the official copy of `EPL-1.0` instead.
This is fixed in d7b51ee1442adc2df9d20dd2e0a535def09b4e23.

I also fixed a typo for epl-v20 license file in the `MANIFEST.in` (7478e83870ea50fd9510aa9f49ade8d18278bee2), which I encountered while fixing the links for `EPL-2.0`.
This appears to be the reason why epl-v20 was not included in any source artifacts of this python package. If I understand this correctly, my change should fix this.

Since this are mostly non-code changes, I did not run the tests, as instructed in the https://github.com/eclipse/paho.mqtt.python/blob/master/CONTRIBUTING.md file. If you could run them yourself, that would be great. If not, let me know and I will try it myself.

Signed-off-by: Jens Keim <jens.keim@forvia.com>