### PR TITLE
application controlled acknowledgements to match Java behaviour

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,12 @@ transport
     set to "websockets" to send MQTT over WebSockets. Leave at the default of
     "tcp" to use raw TCP.
 
+manual_ack
+    defaults to False, allowing the library to acknowledge messages before
+    passing them to on_message callback.  When set to True, every message
+    must be manually acknowledged by application call to 
+    client.ack( *message.mid* )
+
 
 Constructor Example
 ...................

--- a/README.rst
+++ b/README.rst
@@ -201,7 +201,7 @@ manual_ack
     defaults to False, allowing the library to acknowledge messages before
     passing them to on_message callback.  When set to True, every message
     must be manually acknowledged by application call to 
-    client.ack( *message.mid* )
+    client.ack( *message.mid* , *message.qos* )
 
 
 Constructor Example

--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ transport
     "tcp" to use raw TCP.
 
 manual_ack
-    defaults to False, allowing the library to acknowledge messages before
+    defaults to False, allowing the library to acknowledge messages automatically after on_message callback return
     passing them to on_message callback.  When set to True, every message
     must be manually acknowledged by application call to 
     client.ack( *message.mid* , *message.qos* )

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -491,7 +491,8 @@ class Client(object):
     """
 
     def __init__(self, client_id="", clean_session=None, userdata=None,
-                 protocol=MQTTv311, transport="tcp", reconnect_on_failure=True):
+                 protocol=MQTTv311, transport="tcp", reconnect_on_failure=True,
+                 manual_ack=False ):
         """client_id is the unique client id string used when connecting to the
         broker. If client_id is zero length or None, then the behaviour is
         defined by which protocol version is in use. If using MQTT v3.1.1, then
@@ -523,11 +524,20 @@ class Client(object):
 
         Set transport to "websockets" to use WebSockets as the transport
         mechanism. Set to "tcp" to use raw TCP, which is the default.
+
+        Normally, when a message is received, the library automatically
+        acknowledges immediately.  manual_ack=True allows the application to
+        acknowledge receipt after it has completed processing of a message
+        using a the ack() method. This addresses vulnerabilty to message loss
+        if applications fails while processing a message, or while it pending
+        locally.
+
         """
 
         if transport.lower() not in ('websockets', 'tcp'):
             raise ValueError(
                 'transport must be "websockets" or "tcp", not %s' % transport)
+        self._manual_ack = manual_ack
         self._transport = transport.lower()
         self._protocol = protocol
         self._userdata = userdata
@@ -3328,7 +3338,10 @@ class Client(object):
             return MQTT_ERR_SUCCESS
         elif message.qos == 1:
             self._handle_on_message(message)
-            return self._send_puback(message.mid)
+            if self._manual_ack:
+                return MQTT_ERR_SUCCESS
+            else:
+                return self._send_puback(message.mid)
         elif message.qos == 2:
             rc = self._send_pubrec(message.mid)
             message.state = mqtt_ms_wait_for_pubrel
@@ -3337,6 +3350,24 @@ class Client(object):
             return rc
         else:
             return MQTT_ERR_PROTOCOL
+
+    def ack( self, mid ):
+        """
+           send an acknowledgement for a given message id. (stored in message.mid )
+           only useful in QoS=1 and auto_ack=False
+        """
+        if not self._manual_ack :
+            return MQTT_ERR_SUCCESS
+        return self._send_puback(mid)
+
+    def manual_ack( self, on=False ):
+        """
+           The paho library normally acknowledges messages as soon as they are delivered to the caller.
+           If manual_ack is turned on, then the caller MUST manually acknowledge every message once 
+           application processing is complete.
+        """
+        self._manual_ack = on
+
 
     def _handle_pubrel(self):
         if self._protocol == MQTTv5:

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3344,10 +3344,7 @@ class Client(object):
                 return self._send_puback(message.mid)
         elif message.qos == 2:
 
-            if self._manual_ack:
-                rc = MQTT_ERR_SUCCESS
-            else:
-                rc = self._send_pubrec(message.mid)
+            rc = self._send_pubrec(message.mid)
 
             message.state = mqtt_ms_wait_for_pubrel
             with self._in_message_mutex:
@@ -3366,7 +3363,7 @@ class Client(object):
             if qos == 1:
                 return self._send_puback(mid)
             elif qos == 2:
-                return self._send_pubrec(mid)
+                return self._send_pubcomp(mid)
 
         return MQTT_ERR_SUCCESS
 
@@ -3408,7 +3405,10 @@ class Client(object):
         # is possible that we must known about this message.
         # Choose to acknwoledge this messsage (and thus losing a message) but
         # avoid hanging. See #284.
-        return self._send_pubcomp(mid)
+        if self._manual_ack:
+            return MQTT_ERR_SUCCESS
+        else:
+            return self._send_pubcomp(mid)
 
     def _update_inflight(self):
         # Dont lock message_mutex here

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3367,7 +3367,7 @@ class Client(object):
 
         return MQTT_ERR_SUCCESS
 
-    def manual_ack( self, on=False ):
+    def manual_ack_set(self, on):
         """
            The paho library normally acknowledges messages as soon as they are delivered to the caller.
            If manual_ack is turned on, then the caller MUST manually acknowledge every message once 

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -526,7 +526,7 @@ class Client(object):
         mechanism. Set to "tcp" to use raw TCP, which is the default.
 
         Normally, when a message is received, the library automatically
-        acknowledges immediately.  manual_ack=True allows the application to
+        acknowledges after on_message callback returns.  manual_ack=True allows the application to
         acknowledge receipt after it has completed processing of a message
         using a the ack() method. This addresses vulnerabilty to message loss
         if applications fails while processing a message, or while it pending

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3354,7 +3354,7 @@ class Client(object):
         else:
             return MQTT_ERR_PROTOCOL
 
-    def ack( self, mid, qos ):
+    def ack(self, mid: int, qos: int) -> int:
         """
            send an acknowledgement for a given message id. (stored in message.mid )
            only useful in QoS=1 and auto_ack=False


### PR DESCRIPTION
The existing python library acknowledges all messages received after calling the on_message() callback configured by the application.  This PR adds manual_acks=False as an argument to client.py/__init__() function.  When manual_acks=True, the application must acknowledge receipt of every message using the newly created ack(mid,qos) entry point.
  
* Closes #348 


This PR addresses issue  #348 to allow applications to delay acknowledgement until it has completely received it. There was a first PR (#554) submitted two years ago. and got some great feeback from it:

* wanted QoS==2 support (the PR addressed only QoS==1)
* worry about reception order (is the library responsible for ensuring that acknowledgements are sent in the order the messages were received.)

After much too and fro, it was fairly clear that the library cannot be responsible for ordering. Then it occurred to me, that the Java implementation exists, and the equivalent functionality has been present for a number of years, and so chances are that it is doing "the right thing" tm.

So this PR uses the java implementation as a model, and slavishly implements the same thing in Python.

To illustrate the relationship to Java implementation, we can compare some tidbits:

So in python we have:

```

in _handle_publish(self):
     .
     .
     .
      elif message.qos == 1:
            self._handle_on_message(message)
            if self._manual_ack:
                return MQTT_ERR_SUCCESS
            else:
                return self._send_puback(message.mid)

```

vs. Java:

```

in:     private void handleMessage(MqttPublish publishMessage)

                  // If we are not in manual ACK mode:
                if (!this.manualAcks && publishMessage.getMessage().getQos() == 1) {
                        this.clientComms.internalSend(new MqttPubAck(MqttReturnCode.RETURN_CODE_SUCCESS,
                                        publishMessage.getMessageId(), new MqttProperties()),
                                        new MqttToken(clientComms.getClient().getClientId()));
                }

```

There is a need for an implementation of a call to be used by the library user to actually send the acknowledgements.  we can compare code here also:

python:

```
    def ack( self, mid, qos ):
        """
           send an acknowledgement for a given message id. (stored in message.mid )
           only useful in QoS=1 and auto_ack=False
        """
        if self._manual_ack :
            if qos == 1:
                return self._send_puback(mid)
            elif qos == 2:
                return self._send_pubcomp(mid)

        return MQTT_ERR_SUCCESS

```

versus Java:

```

       public void messageArrivedComplete(int messageId, int qos) throws MqttException {
                if (qos == 1) {
                        this.clientComms.internalSend(
                                        new MqttPubAck(MqttReturnCode.RETURN_CODE_SUCCESS, messageId, new MqttProperties()),
                                        new MqttToken(clientComms.getClient().getClientId()));
                } else if (qos == 2) {
                        this.clientComms.deliveryComplete(messageId);
                        MqttPubComp pubComp = new MqttPubComp(MqttReturnCode.RETURN_CODE_SUCCESS, messageId, new MqttProperties());
                        // @TRACE 723=Creating MqttPubComp due to manual ACK: {0}
                        log.info(CLASS_NAME, "messageArrivedComplete", "723", new Object[] { pubComp.toString() });

                        this.clientComms.internalSend(pubComp, new MqttToken(clientComms.getClient().getClientId()));
                }
        }

```

In the java, there was an existing messageArrivedCompleted entry point to adjust.  In python, nothing similar was obvious, so modified _handrel which would only apply in QoS==2... to suppress sending of pubcomp when manual_acks is active.


