### PR TITLE
Add missing proxy property to docstring

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -857,6 +857,8 @@ class Client(object):
         proxy_addr: IP address or DNS name of proxy server
 
         (Optional)
+        proxy_port: (int) port number of the proxy server. If not provided, 
+            the PySocks package default value will be utilized, which differs by proxy_type.
         proxy_rdns: boolean indicating whether proxy lookup should be performed
             remotely (True, default) or locally (False)
         proxy_username: username for SOCKS5 proxy, or userid for SOCKS4 proxy

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -857,7 +857,7 @@ class Client(object):
         proxy_addr: IP address or DNS name of proxy server
 
         (Optional)
-        proxy_port: (int) port number of the proxy server. If not provided, 
+        proxy_port: (int) port number of the proxy server. If not provided,
             the PySocks package default value will be utilized, which differs by proxy_type.
         proxy_rdns: boolean indicating whether proxy lookup should be performed
             remotely (True, default) or locally (False)


### PR DESCRIPTION
Closes issues #461.

It's been quite some time since the issue was created and things might have changed.
While attempting to replicate the _silent failure_ (mentioned by the issue creator), I received an informative error message from the `PySocks` package (`socks.ProxyConnectionError: Error connecting to HTTP proxy example-proxy.com:8080: timed out`).

To get the above error I just extended the basic publish example to include the _proxy_args_ dictionary, including only the required keys.
```python
# examples/publish_single.py
import context  # Ensures paho is in PYTHONPATH

import paho.mqtt.publish as publish
import socks

proxy_dict={
    "proxy_type": socks.HTTP,
    "proxy_addr": "example-proxy.com",
}

publish.single("paho/test/single", "boo", hostname="mqtt.eclipseprojects.io", proxy_args=proxy_dict)
```

The fact that I received an error for port _8080_ raised a flag of a default value, which is the case.
PySocks has a [_DEFAULT_PORTS_ dictionary](https://github.com/Anorov/PySocks/blob/master/socks.py#L112).

I extended the docstring, adding the port as optional.