### PR TITLE
address #713: remove claims of python2 support, as it is no longer su…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ This document describes the source code for the `Eclipse Paho <http://eclipse.or
 
 This code provides a client class which enable applications to connect to an `MQTT <http://mqtt.org/>`_ broker to publish messages, and to subscribe to topics and receive published messages. It also provides some helper functions to make publishing one off messages to an MQTT server very straightforward.
 
-It supports Python 2.7.9+ or 3.6+.
+It supports Python 3.6+.
 
 The MQTT protocol is a machine-to-machine (M2M)/"Internet of Things" connectivity protocol. Designed as an extremely lightweight publish/subscribe messaging transport, it is useful for connections with remote locations where a small code footprint is required and/or network bandwidth is at a premium.
 

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,6 @@ setup(
         'Operating System :: POSIX',
         'Natural Language :: English',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION

* Closes #713
* Closes #714

#713 mentions that paho documentation says that it should be compatible with python 2.7.  Someone answered that python2.7 is not supported.

So this PR corrects the documentation, and metadata to remove claims about python 2 support for the current version.

