### PR TITLE
Fix connect_srv()'s arguments to include bind_port

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -913,13 +913,13 @@ class Client(object):
                            bind_address, bind_port, clean_start, properties)
         return self.reconnect()
 
-    def connect_srv(self, domain=None, keepalive=60, bind_address="",
+    def connect_srv(self, domain=None, keepalive=60, bind_address="", bind_port=0,
                     clean_start=MQTT_CLEAN_START_FIRST_ONLY, properties=None):
         """Connect to a remote broker.
 
         domain is the DNS domain to search for SRV records; if None,
         try to determine local domain name.
-        keepalive, bind_address, clean_start and properties are as for connect()
+        keepalive, bind_address, bind_port, clean_start and properties are as for connect()
         """
 
         if HAVE_DNS is False:
@@ -948,7 +948,7 @@ class Client(object):
             host, port, prio, weight = answer
 
             try:
-                return self.connect(host, port, keepalive, bind_address, clean_start, properties)
+                return self.connect(host, port, keepalive, bind_address, bind_port, clean_start, properties)
             except Exception:
                 pass
 


### PR DESCRIPTION
Fixes this ~3yr old bug https://github.com/eclipse/paho.mqtt.python/issues/493

I think it worth considering reworking this function to use `*args, **kwargs` for these extra arguments, or at least call `connect()` with keyword arguments.
Either one would reduce issues with future failings to manually keep the functions in sync.
But that will likely raise a more intensive workflow discussion, and my goal for this is just to get this 3yr old bug fixed so I can stop using my terrible workarounds.