### PR TITLE
Replace flake8 + isort + bandit with ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[tool.ruff]
+line-length = 167
+
+ignore = [
+    "E402", # TODO: enable
+    "E711", # TODO: enable
+    "E711", # TODO: enable
+    "E712", # TODO: enable
+    "E721", # TODO: enable
+    "S101", # TODO: enable
+    "S110", # TODO: enable
+    "S324", # TODO: enable
+]
+extend-select = [
+    "S", # Bandit
+    "E9",
+    "F63",
+    "F7",
+    "F82",
+    "I",
+]
+
+[tool.ruff.per-file-ignores]
+"{test,tests,examples}/**/*.py" = [
+    "E741",
+    "F401",
+    "F811",
+    "F841",
+    "I",
+    "S",
+]

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -18,7 +18,6 @@ import hashlib
 import logging
 import string
 import struct
-import sys
 import threading
 import time
 import uuid
@@ -3550,7 +3549,6 @@ class Client(object):
         return MQTT_ERR_SUCCESS
 
     def _handle_on_message(self, message):
-        matched = False
 
         try:
             topic = message.topic

--- a/src/paho/mqtt/properties.py
+++ b/src/paho/mqtt/properties.py
@@ -17,7 +17,6 @@
 """
 
 import struct
-import sys
 
 from .packettypes import PacketTypes
 

--- a/src/paho/mqtt/reasoncodes.py
+++ b/src/paho/mqtt/reasoncodes.py
@@ -16,7 +16,6 @@
 *******************************************************************
 """
 
-import sys
 
 from .packettypes import PacketTypes
 

--- a/test/paho_test.py
+++ b/test/paho_test.py
@@ -501,7 +501,7 @@ def gen_connack(flags=0, rc=0, proto_ver=4, properties=b"", property_helper=True
 
         packet = struct.pack('!BBBB', 32, 2+len(properties), flags, rc) + properties
     else:
-        packet = struct.pack('!BBBB', 32, 2, flags, rc);
+        packet = struct.pack('!BBBB', 32, 2, flags, rc)
 
     return packet
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,46 +5,26 @@ envlist = py{37,38,39}
 whitelist_externals = echo make
 deps =
     -rrequirements.txt
-    flake8
+    ruff==0.1.8
 allowlist_externals =
     echo
     make
 commands =
-    # $EXCLUDE is defined above in testenv:py27 as a workaround for Python 2
-    # which does not support asyncio and type hints
-    flake8 . --count --select=E9,F63,F7,F822,F823 --show-source --statistics {env:EXCLUDE:}
+    ruff .
     python setup.py test
     make -C test test
-    # TODO (cclauss) Fix up all these undefined names
-    flake8 . --count --exit-zero --select=F821 --show-source --statistics
 
-# On older Python, flake8 version 4 fail with:
-# RecursionError: maximum recursion depth exceeded
-[testenv:py37]
-deps =
-    -rrequirements.txt
-    flake8<4
-
-# This lint environment should be the same as the one in .github/work
 [testenv:lint]
 deps =
-    bandit
+    -e .
     black
     codespell
-    flake8
-    isort
     mypy
-    pytest
-    pyupgrade
+    ruff==0.1.8
     safety
-    -e .
 commands =
     # The "-" in front of command tells tox to ignore errors
-    bandit --recursive --skip B101,B105,B106,B110,B303,B404,B603,B324 src
     - black --check src
     - codespell
-    flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
-    flake8 src --count --exit-zero --max-complexity=29 --max-line-length=167 --show-source --statistics
-    isort --check-only --profile black src
     - mypy --ignore-missing-imports src
     safety check


### PR DESCRIPTION
This PR is a minimal re-implementation of @cclauss's #718.

It replaces the `flake8`, `isort` and `bandit` linters with [`ruff`](https://docs.astral.sh/ruff/).

Additionally, `tox.ini` gets cleaned up a bit – there were a bunch of lint deps added in 4f0667058f78225609d2ed88fc5fc7d5ee732f7a that weren't actually used or run.