### PR TITLE
Drop mentions of `pylama`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pylama==7.7.1
 pytest
 tox==3.14.0


### PR DESCRIPTION
It isn't used.