### PR TITLE
Fix various typos

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -10,7 +10,7 @@ v2.0.0 - 2023-xx-xx
 v1.6.1 - 2021-10-21
 ===================
 
-- Fix Python 2.7 compatilibity.
+- Fix Python 2.7 compatibility.
 
 
 v1.6.0 - 2021-10-20
@@ -203,7 +203,7 @@ v1.2 - 2016-06-03
 - Allow ^C to interrupt client loop.
 - Fix for keepalive=0 causing an infinite disconnect/reconnect loop. Closes
   #42.
-- Modify callbacks definition/structure to allow classical inheritence. Closes
+- Modify callbacks definition/structure to allow classical inheritance. Closes
   #53, #54.
 - Add websockets support.
 - Default MQTT version is again changed to v3.1.1.

--- a/README.rst
+++ b/README.rst
@@ -95,9 +95,9 @@ The following part of client session is lost:
   that all message passed to publish() has a corresponding on_publish() call.
 
   It also means that the broker may have the Qos2 message in the session. Since the client start
-  with an empty session it don't know it and will re-use the mid. This is not yet fixed.
+  with an empty session it don't know it and will reuse the mid. This is not yet fixed.
 
-Also when clean_session is True, this library will republish QoS > 0 message accross network
+Also when clean_session is True, this library will republish QoS > 0 message across network
 reconnection. This means that QoS > 0 message won't be lost. But the standard say that
 if we should discard any message for which the publish packet was sent. Our choice means that
 we are not compliant with the standard and it's possible for QoS 2 to be received twice.

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3385,7 +3385,7 @@ class Client(object):
         # If unknown it's a protocol error and we should close the connection.
         # But since we don't have (on disk) persistence for the session, it
         # is possible that we must known about this message.
-        # Choose to acknwoledge this messsage (and thus losing a message) but
+        # Choose to acknowledge this message (thus losing a message) but
         # avoid hanging. See #284.
         return self._send_pubcomp(mid)
 
@@ -3925,7 +3925,7 @@ class WebsocketWrapper(object):
                 self._readbuffer = bytearray()
                 self._payload_head = 0
 
-                # respond to non-binary opcodes, their arrival is not guaranteed beacause of non-blocking sockets
+                # respond to non-binary opcodes, their arrival is not guaranteed because of non-blocking sockets
                 if opcode == WebsocketWrapper.OPCODE_CONNCLOSE:
                     frame = self._create_frame(
                         WebsocketWrapper.OPCODE_CONNCLOSE, payload, 0)

--- a/test/ssl/openssl.cnf
+++ b/test/ssl/openssl.cnf
@@ -44,7 +44,7 @@ certs		= $dir/certs		# Where the issued certs are kept
 crl_dir		= $dir/crl		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
-					# several ctificates with same subject.
+					# several certificates with same subject.
 new_certs_dir	= $dir/newcerts		# default place for new certs.
 
 certificate	= test-signing-ca.crt 	# The CA certificate
@@ -55,7 +55,7 @@ crl		= $dir/crl.pem 		# The current CRL
 private_key	= test-signing-ca.key # The private key
 RANDFILE	= $dir/.rand	# private random number file
 
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions	= usr_cert		# The extensions to add to the cert
 
 # Comment out the following two lines for the "traditional"
 # (and highly broken) format.
@@ -162,7 +162,7 @@ default_bits		= 2048
 default_keyfile 	= privkey.pem
 distinguished_name	= req_distinguished_name
 attributes		= req_attributes
-x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 
 # Passwords for private keys if not present they will be prompted for
 # input_password = secret

--- a/tests/test_mqttv5.py
+++ b/tests/test_mqttv5.py
@@ -444,7 +444,7 @@ class Test(unittest.TestCase):
         ocallback.clear()
 
     def test_subscribe_failure(self):
-        # Subscribe failure.  A new feature of MQTT 3.1.1 is the ability to send back negative reponses to subscribe
+        # Subscribe failure.  A new feature of MQTT 3.1.1 is the ability to send back negative responses to subscribe
         # requests.  One way of doing this is to subscribe to a topic which is not allowed to be subscribed to.
         logging.info("Subscribe failure test starting")
 
@@ -479,7 +479,7 @@ class Test(unittest.TestCase):
         # Unsubscribe from one topic
         bclient.unsubscribe(topics[0])
         callback2.wait_unsubscribed()
-        callback2.clear()  # if there were any retained messsages
+        callback2.clear()  # if there were any retained messages
 
         aclient.connect(host="localhost", port=self._test_broker_port)
         aclient.loop_start()


### PR DESCRIPTION
Just a quick pass with `typos-cli` and `codespell`.