### PR TITLE
Add pre-commit plus a GItHub Action to run it

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install pre-commit
+      - use: pre-commit/action@v3.0.0
       - run: pre-commit --version
       - run: pre-commit run --all-files

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -17,5 +17,4 @@ jobs:
           python-version: 3.x
       - run: pip install pre-commit
       - run: pre-commit --version
-      - run: pre-commit install
       - run: pre-commit run --all-files

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -15,6 +15,4 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - use: pre-commit/action@v3.0.0
-      - run: pre-commit --version
-      - run: pre-commit run --all-files
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,0 +1,21 @@
+# https://pre-commit.com
+# This GitHub Action assumes that the repo contains a valid .pre-commit-config.yaml file.
+# Using pre-commit.ci is even better that using GitHub Actions for pre-commit.
+name: pre-commit
+on:
+  pull_request:
+    branches: [master]
+  push:
+  workflow_dispatch:
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install pre-commit
+      - run: pre-commit --version
+      - run: pre-commit install
+      - run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+# Learn more about this config here: https://pre-commit.com/
+
+# To enable these pre-commit hooks run:
+# `brew install pre-commit` or `python3 -m pip install pre-commit`
+# Then in the project root directory run `pre-commit install`
+
+# default_language_version:
+#   python: python3
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-builtin-literals
+      # - id: check-executables-have-shebangs
+      # - id: check-shebang-scripts-are-executable
+      - id: check-toml
+      - id: check-xml
+      - id: check-yaml
+      # - id: detect-private-key
+      # - id: end-of-file-fixer
+      # - id: mixed-line-ending
+      # - id: trailing-whitespace
+
+  #- repo: https://github.com/codespell-project/codespell
+  #  rev: v2.2.6
+  #  hooks:
+  #    - id: codespell  # See pyproject.toml for args
+  #      additional_dependencies:
+  #        - tomli
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.1.9
+    hooks:
+      - id: ruff  # See pyproject.toml for args
+
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.15
+    hooks:
+      - id: validate-pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,15 @@
 [tool.ruff]
-line-length = 167
-
+exclude = ["test/lib/python/*"]
+extend-select = [
+    "S",  # Bandit
+    "E9",
+    "F63",
+    "F7",
+    "F82",
+    "I",
+]
 ignore = [
     "E402", # TODO: enable
-    "E711", # TODO: enable
     "E711", # TODO: enable
     "E712", # TODO: enable
     "E721", # TODO: enable
@@ -11,14 +17,7 @@ ignore = [
     "S110", # TODO: enable
     "S324", # TODO: enable
 ]
-extend-select = [
-    "S", # Bandit
-    "E9",
-    "F63",
-    "F7",
-    "F82",
-    "I",
-]
+line-length = 167
 
 [tool.ruff.per-file-ignores]
 "{test,tests,examples}/**/*.py" = [


### PR DESCRIPTION
As discussed at https://github.com/eclipse/paho.mqtt.python/pull/718#discussion_r1432593177

@akx Your review, please.

Using https://pre-commit.ci is even better than using GitHub Actions for pre-commit.

% `pre-commit run --all-files`
```
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/charliermarsh/ruff-pre-commit.
[INFO] Initializing environment for https://github.com/abravalheri/validate-pyproject.
[INFO] Initializing environment for https://github.com/abravalheri/validate-pyproject:.[all].
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/charliermarsh/ruff-pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/abravalheri/validate-pyproject.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check builtin type constructor use.......................................Passed
check toml...............................................................Passed
check xml............................................(no files to check)Skipped
check yaml...............................................................Passed
ruff.....................................................................Passed
Validate pyproject.toml..................................................Passed
```