### PR TITLE
lint-python.yml: Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -4,7 +4,9 @@ jobs:
   lint_python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - run: pip install tox
       - run: tox -e lint

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,19 +4,14 @@ jobs:
   tox:
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 6
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - run: pip install tox
-      - if: matrix.python == '3.7'
-        run: TOXENV=py37 tox
-      - if: matrix.python == '3.8'
-        run: TOXENV=py38 tox
-      - if: matrix.python == '3.9'
-        run: TOXENV=py39 tox
+      - run: pip install --upgrade setuptools tox
+      - run: tox -e py

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]  # , "3.12"]  # TODO: Fix ssl and add Python 3.12
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - run: pip install --upgrade setuptools tox
+      - run: pip install tox
       - run: tox -e py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pylama==7.7.1
-pytest==5.2.2; python_version >= '3.0'
-pytest-runner==5.2
+pytest
+pytest-runner
 tox==3.14.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py{37,38,39}
+envlist = py{37,38,39,310,311,312},lint
 
 [testenv]
 whitelist_externals = echo make
 deps =
     -rrequirements.txt
-    ruff==0.1.8
+    setuptools
+    ruff==0.1.9
 allowlist_externals =
     echo
     make
@@ -20,7 +21,7 @@ deps =
     black
     codespell
     mypy
-    ruff==0.1.8
+    ruff==0.1.9
     safety
 commands =
     # The "-" in front of command tells tox to ignore errors

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,312},lint
+envlist = py{37,38,39,310,311},lint  # TODO: Fix ssl and add Python 3.12
 
 [testenv]
 whitelist_externals = echo make


### PR DESCRIPTION
* https://github.com/actions/checkout/releases
* https://github.com/actions/setup-python/releases

`"3.10"` MUST be in quotes in YAML... https://dev.to/hugovk/the-python-3-1-problem-85g

---

* #778

Python 3.12 removes the `ssl.wrap_socket()` function. https://docs.python.org/3/whatsnew/3.12.html#ssl
> Any package that still uses `ssl.wrap_socket()` is broken and insecure.

% `python3.12 ./08-ssl-connect-cert-auth-pw.py python/08-ssl-connect-cert-auth-pw.test`
```
Traceback (most recent call last):
  File "/home/runner/work/paho.mqtt.python/paho.mqtt.python/test/lib/./08-ssl-connect-cert-auth-pw.py", line 25, in <module>
    ssock = paho_test.create_server_socket_ssl(cert_reqs=ssl.CERT_REQUIRED)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/paho.mqtt.python/paho.mqtt.python/test/paho_test.py", line 49, in create_server_socket_ssl
    ssock = ssl.wrap_socket(
            ^^^^^^^^^^^^^^^
AttributeError: module 'ssl' has no attribute 'wrap_socket'
```
@akx 