### PR TITLE
Use f-strings where sensible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ extend-select = [
     "F63",
     "F7",
     "F82",
+    "FLY",  # flynt
     "I",
     "S", # Bandit
     "UP",

--- a/src/paho/mqtt/properties.py
+++ b/src/paho/mqtt/properties.py
@@ -259,7 +259,7 @@ class Properties:
             # the name could have spaces in, or not.  Remove spaces before assignment
             if name not in [aname.replace(' ', '') for aname in self.names.keys()]:
                 raise MQTTException(
-                    "Property name must be one of "+str(self.names.keys()))
+                    f"Property name must be one of {self.names.keys()}")
             # check that this attribute applies to the packet type
             if self.packetType not in self.properties[self.getIdentFromName(name)][1]:
                 raise MQTTException(f"Property {name} does not apply to packet type {PacketTypes.Names[self.packetType]}")
@@ -269,23 +269,20 @@ class Properties:
                 if name in ["ReceiveMaximum", "TopicAlias"] \
                         and (value < 1 or value > 65535):
 
-                    raise MQTTException(
-                        "%s property value must be in the range 1-65535" % (name))
+                    raise MQTTException(f"{name} property value must be in the range 1-65535")
                 elif name in ["TopicAliasMaximum"] \
                         and (value < 0 or value > 65535):
 
-                    raise MQTTException(
-                        "%s property value must be in the range 0-65535" % (name))
+                    raise MQTTException(f"{name} property value must be in the range 0-65535")
                 elif name in ["MaximumPacketSize", "SubscriptionIdentifier"] \
                         and (value < 1 or value > 268435455):
 
-                    raise MQTTException(
-                        "%s property value must be in the range 1-268435455" % (name))
+                    raise MQTTException(f"{name} property value must be in the range 1-268435455")
                 elif name in ["RequestResponseInformation", "RequestProblemInformation", "PayloadFormatIndicator"] \
                         and (value != 0 and value != 1):
 
                     raise MQTTException(
-                        "%s property value must be 0 or 1" % (name))
+                        f"{name} property value must be 0 or 1")
 
             if self.allowsMultiple(name):
                 if not isinstance(value, list):
@@ -302,8 +299,7 @@ class Properties:
             if hasattr(self, compressedName):
                 if not first:
                     buffer += ", "
-                buffer += compressedName + " : " + \
-                    str(getattr(self, compressedName))
+                buffer += f"{compressedName} : {getattr(self, compressedName)}"
                 first = False
         buffer += "]"
         return buffer
@@ -422,6 +418,6 @@ class Properties:
             compressedName = propname.replace(' ', '')
             if not self.allowsMultiple(compressedName) and hasattr(self, compressedName):
                 raise MQTTException(
-                    "Property '%s' must not exist more than once" % property)
+                    f"Property '{property}' must not exist more than once")
             setattr(self, propname, value)
         return self, propslen + VBIlen

--- a/src/paho/mqtt/subscribeoptions.py
+++ b/src/paho/mqtt/subscribeoptions.py
@@ -63,7 +63,7 @@ class SubscribeOptions:
     def __setattr__(self, name, value):
         if name not in self.names:
             raise MQTTException(
-                name + " Attribute name must be one of "+str(self.names))
+                f"{name} Attribute name must be one of {self.names}")
         object.__setattr__(self, name, value)
 
     def pack(self):

--- a/tests/mqtt5_props.py
+++ b/tests/mqtt5_props.py
@@ -42,18 +42,18 @@ def gen_uint32_prop(identifier, word):
 
 def gen_string_prop(identifier, s):
     s = s.encode("utf-8")
-    prop = struct.pack('!BH%ds'%(len(s)), identifier, len(s), s)
+    prop = struct.pack(f'!BH{len(s)}s', identifier, len(s), s)
     return prop
 
 def gen_string_pair_prop(identifier, s1, s2):
     s1 = s1.encode("utf-8")
     s2 = s2.encode("utf-8")
-    prop = struct.pack('!BH%dsH%ds'%(len(s1), len(s2)), identifier, len(s1), s1, len(s2), s2)
+    prop = struct.pack(f'!BH{len(s1)}sH{len(s2)}s', identifier, len(s1), s1, len(s2), s2)
     return prop
 
 def gen_varint_prop(identifier, val):
     v = pack_varint(val)
-    return struct.pack("!B"+str(len(v))+"s", identifier, v)
+    return struct.pack(f"!B{len(v)}s", identifier, v)
 
 def pack_varint(varint):
     s = b""

--- a/tests/paho_test.py
+++ b/tests/paho_test.py
@@ -108,14 +108,13 @@ def expect_no_packet(sock, delay=1):
 
 def packet_matches(name, recvd, expected):
     if recvd != expected:
-        print("FAIL: Received incorrect " + name + ".")
+        print(f"FAIL: Received incorrect {name}.")
         try:
-            print("Received: " + to_string(recvd))
+            print(f"Received: {to_string(recvd)}")
         except struct.error:
-            print("Received (not decoded): 0x" +
-                  binascii.b2a_hex(recvd).decode('utf8'))
+            print(f"Received (not decoded): 0x{binascii.b2a_hex(recvd).decode('utf8')}")
         try:
-            print("Expected: " + to_string(expected))
+            print(f"Expected: {to_string(expected)}")
         except struct.error:
             print("Expected (not decoded): 0x" +
                   binascii.b2a_hex(expected).decode('utf8'))
@@ -184,7 +183,7 @@ def do_client_connect(connect_packet, connack_packet, hostname="localhost", port
 
 def remaining_length(packet):
     l = min(5, len(packet))  # noqa: E741
-    all_bytes = struct.unpack("!" + "B" * l, packet[:l])
+    all_bytes = struct.unpack(f"!{'B' * l}", packet[:l])
     mult = 1
     rl = 0
     for i in range(1, l - 1):
@@ -216,7 +215,7 @@ def to_string(packet):
     if len(packet) == 0:
         return ""
 
-    packet0 = struct.unpack("!B%ds" % (len(packet)-1), bytes(packet))
+    packet0 = struct.unpack(f"!B{len(packet) - 1}s", bytes(packet))
     packet0 = packet0[0]
     cmd = packet0 & 0xF0
     if cmd == 0x00:
@@ -409,7 +408,7 @@ def mqtt_read_string(sock, rl):
     slen = sock.recv(2)
     slen, = struct.unpack("!H", slen)
     payload = sock.recv(slen)
-    payload, = struct.unpack("!%ds" % (slen), payload)
+    payload, = struct.unpack(f"!{slen}s", payload)
     rl -= (2 + slen)
     return (payload, rl)
 

--- a/tests/test_mqttv5.py
+++ b/tests/test_mqttv5.py
@@ -456,7 +456,7 @@ class Test(unittest.TestCase):
         response = ocallback.wait_subscribed()
 
         self.assertEqual(response["reasonCodes"][0].getName(), "Unspecified error",
-                         "return code should be 0x80 %s" % response["reasonCodes"][0].getName())
+                         f"return code should be 0x80 {response['reasonCodes'][0].getName()}")
         oclient.disconnect()
         oclient.loop_stop()
 
@@ -701,7 +701,7 @@ class Test(unittest.TestCase):
         connect_properties = Properties(PacketTypes.CONNECT)
         connect_properties.SessionExpiryInterval = 99999
 
-        lbclient, lbcallback = self.new_client(clientid+" b")
+        lbclient, lbcallback = self.new_client(f"{clientid} b")
         lbclient.loop_start()
         lbclient.connect(host="localhost", port=self._test_broker_port, properties=connect_properties)
         lbcallback.wait_connected()
@@ -713,7 +713,7 @@ class Test(unittest.TestCase):
         lbcallback.wait_disconnected()
         lbclient.loop_stop()
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.loop_start()
         laclient.connect(host="localhost", port=self._test_broker_port)
         publish_properties = Properties(PacketTypes.PUBLISH)
@@ -731,7 +731,7 @@ class Test(unittest.TestCase):
                          2, retain=False, properties=publish_properties)
 
         time.sleep(3)
-        lbclient, lbcallback = self.new_client(clientid+" b")
+        lbclient, lbcallback = self.new_client(f"{clientid} b")
         lbclient.loop_start()
         lbclient.connect(host="localhost", port=self._test_broker_port, clean_start=False)
         lbcallback.wait_connected()
@@ -754,7 +754,7 @@ class Test(unittest.TestCase):
         # noLocal
         clientid = 'subscribe options - noLocal'
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port)
         lacallback.wait_connected()
         laclient.loop_start()
@@ -762,7 +762,7 @@ class Test(unittest.TestCase):
             topics[0], options=SubscribeOptions(qos=2, noLocal=True))
         lacallback.wait_subscribed()
 
-        lbclient, lbcallback = self.new_client(clientid+" b")
+        lbclient, lbcallback = self.new_client(f"{clientid} b")
         lbclient.connect(host="localhost", port=self._test_broker_port)
         lbcallback.wait_connected()
         lbclient.loop_start()
@@ -785,7 +785,7 @@ class Test(unittest.TestCase):
 
         # retainAsPublished
         clientid = 'subscribe options - retain as published'
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port)
         lacallback.wait_connected()
         laclient.subscribe(topics[0], options=SubscribeOptions(
@@ -809,7 +809,7 @@ class Test(unittest.TestCase):
 
         # retainHandling
         clientid = 'subscribe options - retain handling'
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port)
         lacallback.wait_connected()
         laclient.publish(topics[1], b"qos 0", 0, retain=True)
@@ -895,7 +895,7 @@ class Test(unittest.TestCase):
     def test_subscription_identifiers(self):
         clientid = 'subscription identifiers'
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port)
         lacallback.wait_connected()
         laclient.loop_start()
@@ -905,7 +905,7 @@ class Test(unittest.TestCase):
         laclient.subscribe(topics[0], qos=2, properties=sub_properties)
         lacallback.wait_subscribed()
 
-        lbclient, lbcallback = self.new_client(clientid+" b")
+        lbclient, lbcallback = self.new_client(f"{clientid} b")
         lbclient.connect(host="localhost", port=self._test_broker_port)
         lbcallback.wait_connected()
         lbclient.loop_start()
@@ -916,7 +916,7 @@ class Test(unittest.TestCase):
 
         sub_properties.clear()
         sub_properties.SubscriptionIdentifier = 3
-        lbclient.subscribe(topics[0]+"/#", qos=2, properties=sub_properties)
+        lbclient.subscribe(f"{topics[0]}/#", qos=2, properties=sub_properties)
 
         lbclient.publish(topics[0], b"sub identifier test", 1, retain=False)
 
@@ -941,12 +941,12 @@ class Test(unittest.TestCase):
     def test_request_response(self):
         clientid = 'request response'
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port)
         lacallback.wait_connected()
         laclient.loop_start()
 
-        lbclient, lbcallback = self.new_client(clientid+" b")
+        lbclient, lbcallback = self.new_client(f"{clientid} b")
         lbclient.connect(host="localhost", port=self._test_broker_port)
         lbcallback.wait_connected()
         lbclient.loop_start()
@@ -994,7 +994,7 @@ class Test(unittest.TestCase):
         connect_properties = Properties(PacketTypes.CONNECT)
         connect_properties.TopicAliasMaximum = 0  # server topic aliases not allowed
         connect_properties.SessionExpiryInterval = 99999
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port, properties=connect_properties)
         connack = lacallback.wait_connected()
         clientTopicAliasMaximum = 0
@@ -1027,7 +1027,7 @@ class Test(unittest.TestCase):
         laclient.loop_stop()
 
         # check aliases have been deleted
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port, clean_start=False,
                          properties=connect_properties)
 
@@ -1051,7 +1051,7 @@ class Test(unittest.TestCase):
         connect_properties = Properties(PacketTypes.CONNECT)
         connect_properties.TopicAliasMaximum = serverTopicAliasMaximum
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port, properties=connect_properties)
         lacallback.wait_connected()
         laclient.loop_start()
@@ -1087,7 +1087,7 @@ class Test(unittest.TestCase):
         connect_properties = Properties(PacketTypes.CONNECT)
         # connect_properties.TopicAliasMaximum = serverTopicAliasMaximum # default is 0
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port, properties=connect_properties)
         lacallback.wait_connected()
         laclient.loop_start()
@@ -1115,7 +1115,7 @@ class Test(unittest.TestCase):
         connect_properties = Properties(PacketTypes.CONNECT)
         connect_properties.TopicAliasMaximum = serverTopicAliasMaximum  # default is 0
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port, properties=connect_properties)
         lacallback.wait_connected()
         laclient.loop_start()
@@ -1143,7 +1143,7 @@ class Test(unittest.TestCase):
         clientid = 'maximum packet size'
 
         # 1. server max packet size
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port)
         connack = lacallback.wait_connected()
         laclient.loop_start()
@@ -1172,7 +1172,7 @@ class Test(unittest.TestCase):
         connect_properties = Properties(PacketTypes.CONNECT)
         connect_properties.MaximumPacketSize = maximumPacketSize
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port, properties=connect_properties)
         connack = lacallback.wait_connected()
         laclient.loop_start()
@@ -1230,7 +1230,7 @@ class Test(unittest.TestCase):
         will_properties.WillDelayInterval = 3  # in seconds
         connect_properties.SessionExpiryInterval = 5
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.will_set(
             topics[0], payload=b"test_will_delay will message", properties=will_properties)
         laclient.connect(host="localhost", port=self._test_broker_port, properties=connect_properties)
@@ -1239,7 +1239,7 @@ class Test(unittest.TestCase):
         self.assertEqual(connack["flags"]["session present"], False)
         laclient.loop_start()
 
-        lbclient, lbcallback = self.new_client(clientid+" b")
+        lbclient, lbcallback = self.new_client(f"{clientid} b")
         lbclient.connect(host="localhost", port=self._test_broker_port, properties=connect_properties)
         connack = lbcallback.wait_connected()
         lbclient.loop_start()
@@ -1266,10 +1266,10 @@ class Test(unittest.TestCase):
     def test_shared_subscriptions(self):
         clientid = 'shared subscriptions'
 
-        shared_sub_topic = '$share/sharename/' + topic_prefix + 'x'
-        shared_pub_topic = topic_prefix + 'x'
+        shared_sub_topic = f"$share/sharename/{topic_prefix}x"
+        shared_pub_topic = f"{topic_prefix}x"
 
-        laclient, lacallback = self.new_client(clientid+" a")
+        laclient, lacallback = self.new_client(f"{clientid} a")
         laclient.connect(host="localhost", port=self._test_broker_port)
         connack = lacallback.wait_connected()
         laclient.loop_start()
@@ -1281,7 +1281,7 @@ class Test(unittest.TestCase):
             [(shared_sub_topic, SubscribeOptions(2)), (topics[0], SubscribeOptions(2))])
         lacallback.wait_subscribed()
 
-        lbclient, lbcallback = self.new_client(clientid+" b")
+        lbclient, lbcallback = self.new_client(f"{clientid} b")
         lbclient.connect(host="localhost", port=self._test_broker_port)
         connack = lbcallback.wait_connected()
         lbclient.loop_start()
@@ -1298,7 +1298,7 @@ class Test(unittest.TestCase):
 
         count = 1
         for i in range(count):
-            lbclient.publish(topics[0], "message "+str(i), 0)
+            lbclient.publish(topics[0], f"message {i}", 0)
         j = 0
         while len(lacallback.messages) + len(lbcallback.messages) < 2*count and j < 20:
             time.sleep(.1)
@@ -1311,7 +1311,7 @@ class Test(unittest.TestCase):
         lbcallback.clear()
 
         for i in range(count):
-            lbclient.publish(shared_pub_topic, "message "+str(i), 0)
+            lbclient.publish(shared_pub_topic, f"message {i}", 0)
         j = 0
         while len(lacallback.messages) + len(lbcallback.messages) < count and j < 20:
             time.sleep(.1)

--- a/tests/test_websocket_integration.py
+++ b/tests/test_websocket_integration.py
@@ -81,7 +81,7 @@ class TestBadWebsocketHeaders:
         class WebsocketHandler(socketserver.BaseRequestHandler):
             def handle(_self):
                 self.data = _self.request.recv(1024).strip()
-                print("Received '{:s}'".format(self.data.decode("utf8")))
+                print('Received', self.data.decode('utf8'))
                 # Respond with data passed in to serve()
                 _self.request.sendall(response)
 
@@ -138,7 +138,7 @@ class TestValidHeaders:
         class WebsocketHandler(socketserver.BaseRequestHandler):
             def handle(_self):
                 self.data = _self.request.recv(1024).strip()
-                print("Received '{:s}'".format(self.data.decode("utf8")))
+                print('Received', self.data.decode('utf8'))
 
                 decoded = self.data.decode("utf8")
 
@@ -202,7 +202,7 @@ class TestValidHeaders:
         def check_path_correct(decoded):
             # Make sure it connects to the right path
             if mqtt_path:
-                assert re.search(f"GET {mqtt_path:s} HTTP/1.1", decoded, re.IGNORECASE) is not None
+                assert re.search(f"GET {mqtt_path} HTTP/1.1", decoded, re.IGNORECASE) is not None
 
         response = self._get_callback_handler(
             init_response_headers,
@@ -237,8 +237,8 @@ class TestValidHeaders:
         def check_headers_used(decoded):
             # Make sure it connects to the right path
             if auth_headers:
-                for h in auth_headers:
-                    assert re.search(f"{h:s}: {auth_headers[h]:s}", decoded, re.IGNORECASE) is not None
+                for k, v in auth_headers.items():
+                    assert f"{k}: {v}" in decoded
 
         response = self._get_callback_handler(
             init_response_headers,


### PR DESCRIPTION
This PR replaces various string formatting operations with Python 3.6+ f-strings, for performance and brevity.

Guided by [Flynt](https://github.com/ikamensh/flynt/) and Ruff's relevant lints, checked by hand.