### PR TITLE
Add spell checking using typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,10 @@ repos:
       # - id: mixed-line-ending
       # - id: trailing-whitespace
 
-  #- repo: https://github.com/codespell-project/codespell
-  #  rev: v2.2.6
-  #  hooks:
-  #    - id: codespell  # See pyproject.toml for args
-  #      additional_dependencies:
-  #        - tomli
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.17.0
+    hooks:
+      - id: typos
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.1.9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Please read the [Eclipse Foundation policy on accepting contributions via Git](h
    cherry-picked to the release branch.
 
    The only changes that goes directly to the release branch (``1.4``,
-   ``1.5``, ...) are bug fixe that does not apply to ``master`` (e.g. because
+   ``1.5``, ...) are bug fixes that does not apply to ``master`` (e.g. because
    there are fixed on master by a refactoring, or any other huge change we do
    not want to cherry-pick to the release branch).
 4. Create a new branch from the latest ```master``` branch

--- a/examples/client_rpc_math.py
+++ b/examples/client_rpc_math.py
@@ -33,7 +33,7 @@ reply_to = ""
 # This correlates the outbound request with the returned reply
 corr_id = b"1"
 
-# This is sent in the message callback when we get the respone
+# This is sent in the message callback when we get the response
 reply = None
 
 # The MQTTv5 callback takes the additional 'props' parameter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,3 +117,10 @@ exclude_also = [
     "raise AssertionError",
     "raise NotImplementedError",
 ]
+
+[tool.typos.default.extend-words]
+Mosquitto = "Mosquitto"
+
+[tool.typos.type.sh.extend-words]
+# gen.sh use the openssl option pass(word) in
+passin = "passin"

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -507,7 +507,7 @@ class Client:
         Normally, when a message is received, the library automatically
         acknowledges after on_message callback returns.  manual_ack=True allows the application to
         acknowledge receipt after it has completed processing of a message
-        using a the ack() method. This addresses vulnerabilty to message loss
+        using a the ack() method. This addresses vulnerability to message loss
         if applications fails while processing a message, or while it pending
         locally.
 

--- a/src/paho/mqtt/properties.py
+++ b/src/paho/mqtt/properties.py
@@ -97,7 +97,7 @@ class VariableByteIntegers:  # Variable Byte Integer
     def encode(x):
         """
           Convert an integer 0 <= x <= 268435455 into multi-byte format.
-          Returns the buffer convered from the integer.
+          Returns the buffer converted from the integer.
         """
         if not 0 <= x <= 268435455:
             raise ValueError(f"Value {x!r} must be in range 0-268435455")

--- a/src/paho/mqtt/subscribe.py
+++ b/src/paho/mqtt/subscribe.py
@@ -251,7 +251,7 @@ def simple(topics, qos=0, msg_count=1, retained=True, hostname="localhost",
                     when it disconnects. If False, the client is a persistent
                     client and subscription information and queued messages
                     will be retained when the client disconnects.
-                    Defaults to True. If protocoll is MQTTv50, clean_session
+                    Defaults to True. If protocol is MQTTv50, clean_session
                     is ignored.
 
     proxy_args: a dictionary that will be given to the client.


### PR DESCRIPTION
Split of https://github.com/eclipse/paho.mqtt.python/pull/786 : contains add of typos to do spell checking