### PR TITLE
Correctly mark connection as broken on SSL error and don't crash loop_forever

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -27,6 +27,8 @@ v2.0.0 - 2023-xx-xx
   and loop_start/loop_forever isn't used. Closes #525.
 - Fix wait_for_publish that could hang with QoS == 0 message on reconnection
   or publish during connection. Closes #549.
+- Correctly mark connection as broken on SSL error and don't crash loop_forever.
+  Closes #750.
 
 
 v1.6.1 - 2021-10-21

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -4313,7 +4313,7 @@ class WebsocketWrapper:
             else:
                 raise BlockingIOError
 
-        except OSError:
+        except ConnectionError:
             self.connected = False
             return b''
 


### PR DESCRIPTION
Catch all OSError as indicator of connection broken. It should especially include SSL error. Also make WebsocketConnectionError a subclass of ConnectionError (which is a subclass of OSError).

Should fix #750.