### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
+# Prerequisites
+
+*Note: You may remove this section prior to submitting your report.*
+
+A small team of volunteers monitors issues. Please help us to help you by making it simple to understand and, if possible,
+replicate your issue. Prior to reporting a bug please:
+
+ - [ ] Test the latest release of the library.
+ - [ ] Search existing issues.
+ - [ ] Read the relevant documentation. 
+ - [ ] Review your server configuration and logs.
+ - [ ] Consider testing against a different server (e.g. [mqtt.eclipseprojects.io](https://mqtt.eclipseprojects.io/) or [test.mosquitto.org](https://test.mosquitto.org/))
+ - [ ] If possible, test using another tool (e.g. [MQTTX](https://mqttx.app/) / [mosquitto_sub](https://mosquitto.org/man/mosquitto_sub-1.html))
+     to confirm the issue is specific to this client.
+ - [ ] If you are unsure if you have found a bug, please consider asking on [stackoverflow](https://stackoverflow.com/) for a quicker response.
+
+# Bug Description
+
+*Please provide a clear and concise description of the bug.* 
+
+# Reproduction
+
+*Please provide detailed steps showing how to replicate the issue (it's difficult to fix an issue we cannot replicate).
+If errors are output then include the full error (including any stack trace).*   
+*Most issues should include a [minimal example](https://stackoverflow.com/help/minimal-reproducible-example) that 
+demonstrates the issue (ideally one that can be run without modification, i.e. runnable code using a public broker).*
+
+# Environment
+
+* Python version:
+* Library version:
+* Operating system (including version):
+* MQTT server (name, version, configuration, hosting details):
+
+# Logs
+
+For many issues, especially when you cannot provide code to replicate the issue, it's helpful to include logs. Please 
+consider including:
+ * library logs; see [the readme](https://github.com/eclipse/paho.mqtt.python#enable_logger) and [logger example](https://github.com/eclipse/paho.mqtt.python/blob/master/examples/client_logger.py).
+ * broker logs (availability will depend the server in use)
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+---
+
+# Prerequisites
+
+*Note: You may remove this section prior to submitting your report.*
+
+A small team of volunteers monitors issues, so it's important that we can quickly understand what you are requesting, and 
+why it would be of benefit. Prior to requesting a feature, please:
+
+- [ ] Search existing issues (the feature may have been requested previously).
+- [ ] Read the relevant documentation.
+- [ ] Consider the impact your feature/idea might have on other users of the library (both positive and negative).
+- [ ] Decide if you are able to implement the feature yourself (please do raise an issue before submitting a pull request).
+
+# Feature Description
+
+*Please provide a clear and concise description of the feature you are requesting. Include details of the benefits you 
+believe the feature will deliver (i.e. problems it will solve, user groups it will help etc).*
+
+# Requested Solution
+
+*Describe how you would like this feature delivered (for example, if adding functionality, show mock code using the new 
+feature)*
+
+# Alternatives
+
+*Have you considered alternative ways of accomplishing your goal? If so please provide details.*
+
+# Additional Information
+
+*Is there any other information you can provide that would help us understand your idea?*

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,43 @@
+---
+name: Question
+about: Ask a question
+title: ''
+labels: ''
+assignees: ''
+---
+
+# Prerequisites
+
+*Note: You may remove this section prior to submitting your question.*
+
+A small team of volunteers monitors issues; this is the same team that develops the library. Whilst we are keen to help,
+there are often better places to ask questions, including:
+
+- [Stack Overflow](https://stackoverflow.com/questions/tagged/mqtt) - well written questions are generally answered 
+within a day. Please use the tags MQTT, Python and Paho.
+- [Reddit](https://www.reddit.com/r/MQTT/) - great for questions requiring discussion.
+- [MQTT Google Group](https://groups.google.com/g/mqtt) - fairly quiet but questions about the protocol are generally answered quickly.
+- [Eclipse paho-dev mailing list](https://dev.eclipse.org/mailman/listinfo/paho-dev) - for general discussion about the paho project.
+
+Prior to asking a question here, please:
+
+- [ ] Search the resources mentioned above (it's likely someone else has asked the same question)
+- [ ] Read the [readme](https://github.com/eclipse/paho.mqtt.python/blob/master/README.rst) (especially the
+"Known limitations" section) and look at the [examples](https://github.com/eclipse/paho.mqtt.python/tree/master/examples).
+- [ ] Search through the [project issues](https://github.com/eclipse/paho.mqtt.python/issues).
+- [ ] Confirm that you are using the latest release of the library.
+- [ ] Ensure your question is specific to this project; consider using another tool (e.g. [MQTTX](https://mqttx.app/) / [mosquitto_sub](https://mosquitto.org/man/mosquitto_sub-1.html))
+to test your assumptions.
+
+# Question
+
+*Please clearly and concisely state your question.*
+
+
+# Environment
+*It's often helpful for us to know how you are using the library so please provide:*
+
+* Python version:
+* Library version:
+* Operating system (including version):
+* MQTT server (name, version, configuration, hosting details):


### PR DESCRIPTION
An initial attempt at issue templates with the goal of improving the quality of issues submitted to the project.

I considered using [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) but they are still in beta so have taken the approach used in other paho projects (but with a bit more content). Please check [my repo](https://github.com/ChIoT-Tech/paho.mqtt.python/issues/new/choose) to see how this will look once accepted.