### PR TITLE
Add tests for reasoncode comparison

### DIFF
--- a/src/paho/mqtt/reasoncodes.py
+++ b/src/paho/mqtt/reasoncodes.py
@@ -16,10 +16,12 @@
 *******************************************************************
 """
 
+import functools
 
 from .packettypes import PacketTypes
 
 
+@functools.total_ordering
 class ReasonCodes:
     """MQTT version 5.0 reason codes class.
 
@@ -173,10 +175,17 @@ class ReasonCodes:
         if isinstance(other, int):
             return self.value == other
         if isinstance(other, str):
-            return self.value == str(self)
+            return other == str(self)
         if isinstance(other, ReasonCodes):
             return self.value == other.value
         return False
+
+    def __lt__(self, other):
+        if isinstance(other, int):
+            return self.value < other
+        if isinstance(other, ReasonCodes):
+            return self.value < other.value
+        return NotImplemented
 
     def __str__(self):
         return self.getName()

--- a/tests/test_reasoncodes.py
+++ b/tests/test_reasoncodes.py
@@ -1,0 +1,26 @@
+from paho.mqtt.packettypes import PacketTypes
+from paho.mqtt.reasoncodes import ReasonCodes
+
+
+class TestReasonCode:
+    def test_equality(self):
+        rc_success = ReasonCodes(PacketTypes.CONNACK, "Success")
+        assert rc_success == 0
+        assert rc_success == "Success"
+        assert rc_success != "Protocol error"
+        assert rc_success == ReasonCodes(PacketTypes.CONNACK, "Success")
+
+        rc_protocol_error = ReasonCodes(PacketTypes.CONNACK, "Protocol error")
+        assert rc_protocol_error == 130
+        assert rc_protocol_error == "Protocol error"
+        assert rc_protocol_error != "Success"
+        assert rc_protocol_error == ReasonCodes(PacketTypes.CONNACK, "Protocol error")
+
+    def test_comparison(self):
+        rc_success = ReasonCodes(PacketTypes.CONNACK, "Success")
+        rc_protocol_error = ReasonCodes(PacketTypes.CONNACK, "Protocol error")
+
+        assert not rc_success > 0
+        assert rc_protocol_error > 0
+        assert not rc_success != 0
+        assert rc_protocol_error != 0


### PR DESCRIPTION
ReasonCodes object could be compared to a number but they couldn't:
* be used in inequality with number like in `reason_code > 0`
* be used in equality with string (because code was broken, it's was intended to work), like in `reason_code == "Success"`

The string comparison if useful IMO. The inequality is there more for compatibility with code that used to do `rc > 0` and want to do `reason_code > 0`.