### PR TITLE
Nicer print in Getting Started example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Here is a very simple example that subscribes to the broker $SYS topic tree and 
 
     # The callback for when the client receives a CONNACK response from the server.
     def on_connect(client, userdata, flags, rc):
-        print("Connected with result code "+str(rc))
+        print("Connected with result code: " + mqtt.connack_string(rc))
 
         # Subscribing in on_connect() means that if we lose the connection and
         # reconnect then subscriptions will be renewed.
@@ -135,9 +135,14 @@ Here is a very simple example that subscribes to the broker $SYS topic tree and 
     def on_message(client, userdata, msg):
         print(msg.topic+" "+str(msg.payload))
 
+    # The callback for when the client disconnects
+    def on_disconnect(client, userdata, rc):
+        print("Disconnected with result code: " + mqtt.error_string(rc))
+    
     client = mqtt.Client()
     client.on_connect = on_connect
     client.on_message = on_message
+    client.on_disconnect = on_disconnect
 
     client.connect("mqtt.eclipseprojects.io", 1883, 60)
 


### PR DESCRIPTION
Using the connack_string and error_string functions to print nicer messages in the Getting Started example.

Makes it easier for users to understand issues without searching for lists of these codes online