### PR TITLE
Fix loop_stop() not clearing ._thread when called from same thread

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2274,7 +2274,7 @@ class Client:
         self._thread_terminate = True
         if threading.current_thread() != self._thread:
             self._thread.join()
-            self._thread = None
+        self._thread = None
 
         return MQTTErrorCode.MQTT_ERR_SUCCESS
 

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2274,7 +2274,6 @@ class Client:
         self._thread_terminate = True
         if threading.current_thread() != self._thread:
             self._thread.join()
-        self._thread = None
 
         return MQTTErrorCode.MQTT_ERR_SUCCESS
 
@@ -4420,6 +4419,7 @@ class Client:
 
     def _thread_main(self) -> None:
         self.loop_forever(retry_first_connection=True)
+        self._thread = None
 
     def _reconnect_wait(self) -> None:
         # See reconnect_delay_set for details

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -4418,8 +4418,10 @@ class Client:
                         MQTT_LOG_ERR, 'Caught exception in on_connect_fail: %s', err)
 
     def _thread_main(self) -> None:
-        self.loop_forever(retry_first_connection=True)
-        self._thread = None
+        try:
+            self.loop_forever(retry_first_connection=True)
+        finally:
+            self._thread = None
 
     def _reconnect_wait(self) -> None:
         # See reconnect_delay_set for details


### PR DESCRIPTION
When client.loop_stop() is called from within on_message() callback, client ._thread will not be set to None. This will cause subsequent loop_start() to return MQTT_ERR_INVAL error.
