### PR TITLE
Fix type annotations

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -288,7 +288,7 @@ class WebsocketConnectionError(ConnectionError):
     pass
 
 
-def error_string(mqtt_errno: MQTTErrorCode) -> str:
+def error_string(mqtt_errno: MQTTErrorCode | int) -> str:
     """Return the error string associated with an mqtt error number."""
     if mqtt_errno == MQTT_ERR_SUCCESS:
         return "No error."
@@ -729,7 +729,7 @@ class Client:
     def __init__(
         self,
         callback_api_version: CallbackAPIVersion,
-        client_id: str = "",
+        client_id: str | None = "",
         clean_session: bool | None = None,
         userdata: Any = None,
         protocol: int = MQTTv311,
@@ -2032,7 +2032,7 @@ class Client:
         return self._send_subscribe(False, topic_qos_list, properties)
 
     def unsubscribe(
-        self, topic: str, properties: Properties | None = None
+        self, topic: str | list[str], properties: Properties | None = None
     ) -> tuple[MQTTErrorCode, int | None]:
         """Unsubscribe the client from one or more topics.
 

--- a/src/paho/mqtt/reasoncodes.py
+++ b/src/paho/mqtt/reasoncodes.py
@@ -30,7 +30,7 @@ class ReasonCode:
 
     """
 
-    def __init__(self, packetType, aName="Success", identifier=-1):
+    def __init__(self, packetType: int, aName: str ="Success", identifier: int =-1):
         """
         packetType: the type of the packet, such as PacketTypes.CONNECT that
             this reason code will be used with.  Some reason codes have different


### PR DESCRIPTION
Hi,
Thank you for updating and modernizing paho-mqtt.

I am a maintainer of aiomqtt, a wrapper around paho-mqtt.
When migrating to paho-mqtt 2.0, we encountered some type regressions as we were using [types-paho-mqtt](https://pypi.org/project/types-paho-mqtt/).

This PR fix all the types errors on aiomqtt.