### PR TITLE
Remedy breaking change with 2.x: Use `CallbackAPIVersion.VERSION1` as a default

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -728,7 +728,7 @@ class Client:
 
     def __init__(
         self,
-        callback_api_version: CallbackAPIVersion,
+        callback_api_version: CallbackAPIVersion = CallbackAPIVersion.VERSION1,
         client_id: str | None = "",
         clean_session: bool | None = None,
         userdata: Any = None,


### PR DESCRIPTION
Dear @PierreF and @ralight,

first things first: Thanks a stack for conceiving and maintaining paho-mqtt.

We have been tripped by paho-mqtt 2.0.0 causing downstream havocs, because of incompatibilites. On pytest-mqtt, a corresponding minimal adjustment to make it compatible with both versions of paho-mqtt 1.x and 2.x looks like this:

- https://github.com/mqtt-tools/pytest-mqtt/pull/18

### Thoughts
As opposed to the rationale provided at https://github.com/eclipse/paho.mqtt.python/issues/814#issuecomment-1942854199, we think not introducing a breaking change on the most prominent spot will improve adoption rates, because users can run their code with both versions of paho-mqtt 1.x and 2.x, so it will be much easier to switch forth and back for conducting orientation flights on various levels of bringing code from development into production stages.

We don't think it will cause any harm, and other confusions. If the new API is documented properly, the word about it will progressively spread, and everyone will be happy?

We are probably wrong on many levels, not taking into account any discussions you certainly had about this topic. In this spirit, feel free to close this PR without further ado or notice.

Keep up the good work!

With kind regards,
Andreas.
