### PR TITLE
Fix links for migrations.rst document

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,7 +4,7 @@ v2.0.0 - 2024-02-10
 This release include breaking change. See `migrations <https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html>`_ for more details on how to upgrade.
 
 - **BREAKING** Added callback_api_version. This break *ALL* users of paho-mqtt Client class.
-  See migrations.md for details on how to upgrade.
+  See docs/migrations.rst or `online version <https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html>`_ for details on how to upgrade.
   tl; dr; add CallbackAPIVersion.VERSION1 to first argument of Client()
 - **BREAKING** Drop support for Python 2.7, Python 3.5 and Python 3.6
   Minimum tested version is Python 3.7

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -648,7 +648,7 @@ class Client:
 
     :param CallbackAPIVersion callback_api_version: define the API version for user-callback (on_connect, on_publish,...).
         This field is required and it's recommended to use the latest version (CallbackAPIVersion.API_VERSION2).
-        See each callback for description of API for each version. The file migrations.md contains details on
+        See each callback for description of API for each version. The file docs/migrations.rst contains details on
         how to migrate between version.
 
     :param str client_id: the unique client id string used when connecting to the
@@ -764,7 +764,7 @@ class Client:
             # Help user to migrate, it probably provided a client id
             # as first arguments
             raise ValueError(
-                "Unsupported callback API version: version 2.0 added a callback_api_version, see migrations.md for details"
+                "Unsupported callback API version: version 2.0 added a callback_api_version, see docs/migrations.rst for details"
             )
         if self._callback_api_version not in CallbackAPIVersion:
             raise ValueError("Unsupported callback API version")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -688,7 +688,7 @@ class TestCompatibility:
         assert rc_ok + 1 == 1
 
     def test_migration_callback_version(self):
-        with pytest.raises(ValueError, match="see migrations.md"):
+        with pytest.raises(ValueError, match="see docs/migrations.rst"):
             _ = client.Client("client-id")
 
     def test_callback_v1_mqtt3(self, fake_broker):


### PR DESCRIPTION
> On a linked note the error says see migrations.md for details but that file is not obvious in the repo

https://github.com/eclipse/paho.mqtt.python/issues/814#issuecomment-1940562652