### PR TITLE
Add missing mapping for setsockopt to _WebsocketWrapper

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -92,7 +92,8 @@ if TYPE_CHECKING:
             ...
         def setblocking(self, flag: bool) -> None:
             ...
-
+        def setsockopt(self, level: int, optname: int, value: Any) -> None:
+            ...
 
 try:
     import ssl
@@ -5002,3 +5003,6 @@ class _WebsocketWrapper:
 
     def setblocking(self, flag: bool) -> None:
         self._socket.setblocking(flag)
+
+    def setsockopt(self, level: int, optname: int, value: Any) -> None:
+        self._socket.setsockopt(level, optname, value)

--- a/tests/test_websocket_integration.py
+++ b/tests/test_websocket_integration.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import re
 import socketserver
+import socket
 from collections import OrderedDict
 
 import paho.mqtt.client as client
@@ -182,6 +183,8 @@ class TestValidHeaders:
         with fake_websocket_broker.serve(response):
             mqttc.connect("localhost", fake_websocket_broker.port, keepalive=10)
 
+            mqttc.socket().setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
             mqttc.disconnect()
 
     @pytest.mark.parametrize("mqtt_path", [
@@ -255,3 +258,4 @@ class TestValidHeaders:
             mqttc.connect("localhost", fake_websocket_broker.port, keepalive=10)
 
             mqttc.disconnect()
+


### PR DESCRIPTION
Fixes the asyncio example with a websocket wrapped socket https://github.com/eclipse/paho.mqtt.python/blob/d45de3737879cfe7a6acc361631fa5cb1ef584bb/examples/loop_asyncio.py#L92