### PR TITLE
Draft: Add support for PyOpenSSL in paho.mqtt.python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = []
 proxy = [
     "PySocks",
 ]
+openssl = [
+    "pyOpenSSL"
+]
 
 [project.urls]
 Homepage = "http://eclipse.org/paho"

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1153,7 +1153,7 @@ class Client:
                     self._call_socket_register_write()
                     raise BlockingIOError() from err
                 except SSL.ZeroReturnError as err:
-                    raise BlockingIOError() from err
+                    raise ConnectionError() from err
                 except AttributeError as err:
                     self._easy_log(MQTT_LOG_DEBUG, "socket was None: %s", err)
                     raise ConnectionError() from err
@@ -1196,7 +1196,7 @@ class Client:
                     self._call_socket_register_write()
                     raise BlockingIOError() from err
                 except SSL.ZeroReturnError as err:
-                    raise BlockingIOError() from err
+                    raise ConnectionError() from err
                 except BlockingIOError as err:
                     self._call_socket_register_write()
                     raise BlockingIOError() from err

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -58,7 +58,6 @@ try:
                 san_entries = ext.__str__().split(', ')
                 for entry in san_entries:
                     key, value = entry.split(':', 1)
-                    print(f"key {key}: value {value}")
                     san.append((key.strip(), value.strip()))
         return san
 

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1152,7 +1152,11 @@ class Client:
                 except SSL.WantWriteError as err:
                     self._call_socket_register_write()
                     raise BlockingIOError() from err
+                except SSL.WantX509LookupError as err:
+                    raise ConnectionError() from err
                 except SSL.ZeroReturnError as err:
+                    raise ConnectionError() from err
+                except SSL.SysCallError as err:
                     raise ConnectionError() from err
                 except AttributeError as err:
                     self._easy_log(MQTT_LOG_DEBUG, "socket was None: %s", err)
@@ -1195,7 +1199,11 @@ class Client:
                 except SSL.WantWriteError as err:
                     self._call_socket_register_write()
                     raise BlockingIOError() from err
+                except SSL.WantX509LookupError as err:
+                    raise ConnectionError() from err
                 except SSL.ZeroReturnError as err:
+                    raise ConnectionError() from err
+                except SSL.SysCallError as err:
                     raise ConnectionError() from err
                 except BlockingIOError as err:
                     self._call_socket_register_write()


### PR DESCRIPTION
This PR aims to introduce support for PyOpenSSL in the `paho.mqtt.python` library. The primary focus is on enabling the provision of a custom `SSL.Context` within the MQTT client. This enhancement is essential for ensuring compatibility with PKCS#11, as discussed in issue #646.

## Changes:

- Added functionality to provide a custom `SSL.Context` within the MQTT client.
- Utilized the `tls_set_context` method to facilitate compatibility with both `ssl.SSLContext` and `SSL.Context`.

## Purpose:

The introduction of PyOpenSSL support serves to broaden the library's compatibility spectrum, particularly for scenarios involving PKCS#11 integration. This enhancement enhances the versatility and usability of the `paho.mqtt.python` library.

## Related Issue:

- #646

## Related Work:

- [PyOpenSSL with azure-iot-sdk-python](https://github.com/IniterWorker/azure-iot-sdk-python/tree/feature/pyopenssl-openssl-pkcs11)

## Notes for Reviewers:

Your feedback on the implementation approach and any suggestions for further improvements are highly appreciated.
