### PR TITLE
Seperate keepalive 0 from socket `settimeout` 

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -4612,7 +4612,7 @@ class Client:
             sock = self._ssl_wrap_socket(sock)
 
         if self._transport == "websockets":
-            sock.settimeout(self._keepalive)
+            sock.settimeout(self._connect_timeout)
             return _WebsocketWrapper(
                 socket=sock,
                 host=self._host,
@@ -4667,7 +4667,7 @@ class Client:
             if getattr(self._ssl_context, 'check_hostname', False):  # type: ignore
                 verify_host = False
 
-        ssl_sock.settimeout(self._keepalive)
+        ssl_sock.settimeout(self._connect_timeout)
         ssl_sock.do_handshake()
 
         if verify_host:


### PR DESCRIPTION
In certain conditions (MQTT over SSL, and also some websockets stuff) _keepalive is used as a socket timeout, which is all good until used with `0`, which triggers as #42 describes it "an infinite loop" preventing any connection from being established. Originally in our testing only the SSL code path was triggered, and referring an older change (#578) _connect_timeout can be used as an alternative, which also semantically makes sense. 

I noticed the same value was used on another socket for websocket transports, and with some quick testing both cases fail with keepalive 0:

Using test.mosquitto.org with websockets:

```python
...
>>> client.connect(url, port, keepalive=0)
... (stack trace)
BlockingIOError: [Errno 11] Resource temporarily unavailable
``` 

And over SSL:

```python
...
>>> client.connect(url, port, keepalive=0)
... (stack trace)
ssl.SSLWantReadError: The operation did not complete (read) (_ssl.c:1000)
```

Both TLS and WebSocket rely on initial communication beyond the socket connection to establish a connection which makes a timeout of 0 impossible to respect for either protocol.

Using a seperate value which is non-zero seems to make more sense, although the meaning of `keepalive` fits the `settimeout` functionality better, so perhaps only calling it for values greater than 0?

