### PR TITLE
Make the _loop function update the inflight packet

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -1704,7 +1704,11 @@ class Client:
             if rc or self._sock is None:
                 return rc
 
-        return self.loop_misc()
+        rc = self.loop_misc()
+        if rc == MQTT_ERR_SUCCESS:
+            # Make the main loop to update inflight packets
+            return self._update_inflight()
+        return rc
 
     def publish(
         self,


### PR DESCRIPTION
Make the _loop function update the inflight packet queue to prevent QOS 1 messages to stuck in the queue if we miss broker response or if the broker miss our packet