### PR TITLE
Do not decrease inflight messages on `PUBREL`

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3718,12 +3718,10 @@ class Client:
                     if m.qos == 0:
                         m.state = mqtt_ms_publish
                     elif m.qos == 1:
-                        # self._inflight_messages = self._inflight_messages + 1
                         if m.state == mqtt_ms_wait_for_puback:
                             m.dup = True
                         m.state = mqtt_ms_publish
                     elif m.qos == 2:
-                        # self._inflight_messages = self._inflight_messages + 1
                         if self._check_clean_session():
                             if m.state != mqtt_ms_publish:
                                 m.dup = True
@@ -4208,7 +4206,6 @@ class Client:
                 # prevents multiple callbacks for the same message.
                 message = self._in_messages.pop(mid)
                 self._handle_on_message(message)
-                self._inflight_messages -= 1
                 if self._max_inflight_messages > 0:
                     with self._out_message_mutex:
                         rc = self._update_inflight()


### PR DESCRIPTION
When a QoS 2 message is received, the inflight messages was decremented on `PUBREL`. But the inflight messages must be a count of sent but not received messages. This yielded a negative inflight count for QoS 2 messages.

This change removes this decrement and fixes #805.