### PR TITLE
Make documented client re-exports explicit

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -39,11 +39,23 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, NamedTupl
 
 from paho.mqtt.packettypes import PacketTypes
 
-from .enums import CallbackAPIVersion, ConnackCode, LogLevel, MessageState, MessageType, MQTTErrorCode, MQTTProtocolVersion, PahoClientMode, _ConnectionState
+# Re-export public enums and helper types explicitly so static type checkers
+# treat the documented ``paho.mqtt.client`` module surface as exported API.
+from .enums import (
+    CallbackAPIVersion as CallbackAPIVersion,
+    ConnackCode as ConnackCode,
+    LogLevel as LogLevel,
+    MessageState as MessageState,
+    MessageType as MessageType,
+    MQTTErrorCode as MQTTErrorCode,
+    MQTTProtocolVersion as MQTTProtocolVersion,
+    PahoClientMode as PahoClientMode,
+    _ConnectionState,
+)
 from .matcher import MQTTMatcher
-from .properties import Properties
-from .reasoncodes import ReasonCode, ReasonCodes
-from .subscribeoptions import SubscribeOptions
+from .properties import Properties as Properties
+from .reasoncodes import ReasonCode as ReasonCode, ReasonCodes as ReasonCodes
+from .subscribeoptions import SubscribeOptions as SubscribeOptions
 
 try:
     from typing import Literal

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,12 @@ import tests.paho_test as paho_test
 from tests.testsupport.broker import FakeBroker, fake_broker  # noqa: F401
 
 
+def test_documented_public_reexports() -> None:
+    assert client.CallbackAPIVersion is CallbackAPIVersion
+    assert client.Properties is Properties
+    assert client.ReasonCode is ReasonCode
+
+
 @pytest.mark.parametrize("proto_ver,callback_version", [
     (MQTTProtocolVersion.MQTTv31, CallbackAPIVersion.VERSION1),
     (MQTTProtocolVersion.MQTTv31, CallbackAPIVersion.VERSION2),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,10 +4,20 @@ import unicodedata
 
 import paho.mqtt.client as client
 import pytest
-from paho.mqtt.enums import CallbackAPIVersion, MQTTErrorCode, MQTTProtocolVersion
+from paho.mqtt.enums import (
+    CallbackAPIVersion,
+    ConnackCode,
+    LogLevel,
+    MessageState,
+    MessageType,
+    MQTTErrorCode,
+    MQTTProtocolVersion,
+    PahoClientMode,
+)
 from paho.mqtt.packettypes import PacketTypes
 from paho.mqtt.properties import Properties
-from paho.mqtt.reasoncodes import ReasonCode
+from paho.mqtt.reasoncodes import ReasonCode, ReasonCodes
+from paho.mqtt.subscribeoptions import SubscribeOptions
 
 import tests.paho_test as paho_test
 
@@ -16,9 +26,23 @@ from tests.testsupport.broker import FakeBroker, fake_broker  # noqa: F401
 
 
 def test_documented_public_reexports() -> None:
-    assert client.CallbackAPIVersion is CallbackAPIVersion
-    assert client.Properties is Properties
-    assert client.ReasonCode is ReasonCode
+    expected_public_api = {
+        "CallbackAPIVersion": CallbackAPIVersion,
+        "ConnackCode": ConnackCode,
+        "LogLevel": LogLevel,
+        "MessageState": MessageState,
+        "MessageType": MessageType,
+        "MQTTErrorCode": MQTTErrorCode,
+        "MQTTProtocolVersion": MQTTProtocolVersion,
+        "PahoClientMode": PahoClientMode,
+        "Properties": Properties,
+        "ReasonCode": ReasonCode,
+        "ReasonCodes": ReasonCodes,
+        "SubscribeOptions": SubscribeOptions,
+    }
+
+    for name, expected in expected_public_api.items():
+        assert getattr(client, name) is expected
 
 
 @pytest.mark.parametrize("proto_ver,callback_version", [


### PR DESCRIPTION
## Summary
- make the documented `paho.mqtt.client` re-exports explicit so static type checkers treat them as public API
- add a regression test that locks the documented module-level exports in place

## Testing
- `python -m pytest tests/test_client.py -k documented_public_reexports -q`
- validated with `pyright` against a minimal reproducer for `mqtt.CallbackAPIVersion` and `mqtt.Properties`

Closes #892