### PR TITLE
Update supported Python version

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,312}
+envlist = py{39,310,311,312,313,314}
 
 [testenv]
 deps =


### PR DESCRIPTION
Drop old Python 3.7 and 3.8. Both are EOL for more than 1 year and no longer supported by Github CI.

Add Python 3.13 and 3.14.