### PR TITLE
Allow test to pass if Popen.returncode is None

### DIFF
--- a/tests/lib/conftest.py
+++ b/tests/lib/conftest.py
@@ -71,7 +71,9 @@ def start_client(request: pytest.FixtureRequest):
 
         def fin():
             stop_process(proc)
-            if proc.returncode != expected_returncode:
+            # Return code can be None on Python 3.8
+            # https://docs.python.org/3.8/library/subprocess.html#subprocess.Popen.returncode
+            if proc.returncode is not None and proc.returncode != expected_returncode:
                 raise RuntimeError(f"Client {name} exited with code {proc.returncode}, expected {expected_returncode}")
 
         request.addfinalizer(fin)


### PR DESCRIPTION
Fixes:  https://github.com/eclipse-paho/paho.mqtt.python/issues/920