### PR TITLE
Fix test failure on python 3.7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [master]
   push:
-    branches: [master]
+    branches: [master, Fix_test_failure_on_Python_3.8]
 jobs:
   tox:
     strategy:
@@ -20,13 +20,20 @@ jobs:
           repository: eclipse/paho.mqtt.testing
           ref: a4dc694010217b291ee78ee13a6d1db812f9babd
           path: paho.mqtt.testing
+          
+      - uses: LizardByte/actions/actions/setup_python@v2026.605.34721
+        if: ${{ matrix.python == '3.7' }}
+        with:
+          python-version: ${{ matrix.python }}
       - uses: actions/setup-python@v5
+        if: ${{ matrix.python != '3.7' }}
         with:
           python-version: ${{ matrix.python }}
           cache: pip
           cache-dependency-path: |
             tox.ini
             setup.py
+
       - run: pip install tox
       - run: tox -e py
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [master]
   push:
-    branches: [master, Fix_test_failure_on_Python_3.8]
+    branches: [master, "Fix_test_failure_on_Python_3.7", "Fix_test_failure_on_Python_3.8"]
 jobs:
   tox:
     strategy:
@@ -20,7 +20,7 @@ jobs:
           repository: eclipse/paho.mqtt.testing
           ref: a4dc694010217b291ee78ee13a6d1db812f9babd
           path: paho.mqtt.testing
-          
+
       - uses: LizardByte/actions/actions/setup_python@v2026.605.34721
         if: ${{ matrix.python == '3.7' }}
         with:


### PR DESCRIPTION
Fixes https://github.com/eclipse-paho/paho.mqtt.python/issues/919

Uses LizardByte setup Python action to setup Python 3.7 (with pyenv)

<img width="1049" height="489" alt="image" src="https://github.com/user-attachments/assets/5eec00ca-29c8-4655-ad1c-a730a632202a" />
