### PR TITLE
docs: document exceptions raised by MQTTMessageInfo.is_published

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -574,7 +574,15 @@ class MQTTMessageInfo:
         """Returns True if the message associated with this object has been
         published, else returns False.
 
-        To wait for this to become true, look at `wait_for_publish`.
+        Returning False does not mean the publication failed; it means the
+        publication has not completed yet. To wait for this to become true,
+        look at `wait_for_publish`.
+
+        :raises ValueError: if the message was not queued due to the outgoing
+            queue being full.
+
+        :raises RuntimeError: if the message was not published for another
+            reason.
         """
         if self.rc == MQTTErrorCode.MQTT_ERR_QUEUE_SIZE:
             raise ValueError('Message is not queued due to ERR_QUEUE_SIZE')


### PR DESCRIPTION
Fixes #906

`is_published()` raises the same `ValueError`/`RuntimeError` as `wait_for_publish()`, but its docstring did not mention them. This PR copies the `:raises:` documentation over and clarifies that a `False` return means publication has not completed yet — not that it failed.

No behavior change; docstring only.
