### PR TITLE
Change self._keepalive to self._connect_timeout in .settimeout calls

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -4642,7 +4642,7 @@ class Client:
             sock = self._ssl_wrap_socket(sock)
 
         if self._transport == "websockets":
-            sock.settimeout(self._keepalive)
+            sock.settimeout(self._connect_timeout)
             return _WebsocketWrapper(
                 socket=sock,
                 host=self._host,
@@ -4697,7 +4697,7 @@ class Client:
             if getattr(self._ssl_context, 'check_hostname', False):  # type: ignore
                 verify_host = False
 
-        ssl_sock.settimeout(self._keepalive)
+        ssl_sock.settimeout(self._connect_timeout)
         ssl_sock.do_handshake()
 
         if verify_host:


### PR DESCRIPTION
Fixes #890 (hopefully).  As I said in that issue, when commit https://github.com/eclipse-paho/paho.mqtt.python/commit/8aab958a785430bee641294875a865acdff95ea2 added the websocket .settimeout line, there was no self._connect_timeout, so it used self._keepalive instead.  

I've made the same change to a similar call on ssl_sock too.
