### PR TITLE
fix: honor Server Keep Alive from MQTT 5.0 CONNACK

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -3891,6 +3891,11 @@ class Client:
                 reason = ReasonCode(CONNACK >> 4, identifier=result)
                 properties = Properties(CONNACK >> 4)
                 properties.unpack(self._in_packet['packet'][2:])
+                if hasattr(properties, "ServerKeepAlive"):
+                    # MQTT 5.0: when the server returns a Server Keep Alive in
+                    # CONNACK, the client must use that value instead of the one
+                    # it sent (MQTT 5.0 spec 3.2.2.3.14).
+                    self._keepalive = properties.ServerKeepAlive
         else:
             (flags, result) = struct.unpack("!BB", self._in_packet['packet'])
             reason = convert_connack_rc_to_reason_code(result)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ from paho.mqtt.packettypes import PacketTypes
 from paho.mqtt.properties import Properties
 from paho.mqtt.reasoncodes import ReasonCode
 
+import tests.mqtt5_props as mqtt5_props
 import tests.paho_test as paho_test
 
 # Import test fixture
@@ -255,6 +256,48 @@ class Test_connect_v5:
 
             packet_in = fake_broker.receive_packet(1)
             assert not packet_in  # Check connection is closed
+
+        finally:
+            mqttc.loop_stop()
+
+    def test_connack_server_keep_alive(self, fake_broker):
+        mqttc = client.Client(
+            CallbackAPIVersion.VERSION2, "connack-server-keep-alive",
+            protocol=MQTTProtocolVersion.MQTTv5, transport=fake_broker.transport)
+
+        # Client connects requesting the default keepalive of 60.
+        assert mqttc._keepalive == 60
+
+        is_connected = threading.Event()
+
+        def on_connect(mqttc, obj, flags, reason, properties):
+            assert reason == 0
+            is_connected.set()
+
+        mqttc.on_connect = on_connect
+
+        mqttc.connect_async("localhost", fake_broker.port)
+        mqttc.loop_start()
+
+        try:
+            fake_broker.start()
+
+            packet_in = fake_broker.receive_packet(1000)
+            assert packet_in  # Check connection was not closed
+
+            # Broker overrides the keepalive with a Server Keep Alive of 42
+            # (a value other than the default 60 so the override is unambiguous).
+            server_keep_alive = mqtt5_props.gen_uint16_prop(
+                mqtt5_props.PROP_SERVER_KEEP_ALIVE, 42)
+            connack_packet = paho_test.gen_connack(
+                rc=0, proto_ver=5, properties=server_keep_alive)
+            count = fake_broker.send_packet(connack_packet)
+            assert count == len(connack_packet)
+
+            is_connected.wait()
+
+            # Per MQTT 5.0 (3.2.2.3.14) the client must adopt the server value.
+            assert mqttc._keepalive == 42
 
         finally:
             mqttc.loop_stop()


### PR DESCRIPTION
Fixes #905

## Problem

Per MQTT 5.0 §3.2.2.3.14, when the server returns a **Server Keep Alive** in the CONNACK, the client MUST use that value instead of the keepalive it sent. paho did not apply it, so ping timing kept using the client's original value and users had to work around it by setting keepalive in `on_connect` (which the setter blocks anyway).

## Change

In `_handle_connack()`, after unpacking the CONNACK properties, apply the Server Keep Alive when present:

```python
if hasattr(properties, "ServerKeepAlive"):
    self._keepalive = properties.ServerKeepAlive
```

This handles it automatically inside paho, as suggested by @JamesParrott in #905. `self._keepalive` is what the ping scheduler uses, so subsequent PINGREQ timing follows the server's value.

## Notes

- Only affects the MQTT v5 path; v3.x is unchanged (no properties).
- `hasattr` guards the case where the server omits the property.
- Happy to add a test using the v5 test harness if you'd like one.
